### PR TITLE
Add null check for parsedLogs[0]

### DIFF
--- a/BlobForwarder/index.js
+++ b/BlobForwarder/index.js
@@ -184,7 +184,7 @@ function transformData(logs, context) {
     return buffer;
   }
 
-  if (typeof parsedLogs[0] === 'object') {
+  if (typeof parsedLogs[0] === 'object' && parsedLogs[0] !== null) {
     // type JSON records
     if (parsedLogs[0].records !== undefined) {
       context.log('Type of logs: records Array');

--- a/EventHubForwarder/index.js
+++ b/EventHubForwarder/index.js
@@ -178,7 +178,7 @@ function transformData(logs, context) {
     return buffer;
   }
 
-  if (typeof parsedLogs[0] === 'object') {
+  if (typeof parsedLogs[0] === 'object' && parsedLogs[0] !== null) {
     // type JSON records
     if (parsedLogs[0].records !== undefined) {
       context.log('Type of logs: records Array');
@@ -193,12 +193,14 @@ function transformData(logs, context) {
     // Our API can parse the data in "log" to a JSON and ignore "message", so we are good!
     return buffer;
   }
+
   if (typeof parsedLogs[0] === 'string') {
     // type string array
     context.log('Type of logs: string Array');
     parsedLogs.forEach((logString) => buffer.push({ message: logString }));
     return buffer;
   }
+
   return buffer;
 }
 


### PR DESCRIPTION
Hi!

This adds a null check on the EventHub and BlobStorage forwarders function because `typeof null === "object"` so it will throw an exception when tries to get `parsedLogs[0].record` if `parsedLogs[0]` is `null`

Regards!