### PR TITLE
fix: Producer policy should depend on consumer policy

### DIFF
--- a/armTemplates/azuredeploy-eventhubforwarder.json
+++ b/armTemplates/azuredeploy-eventhubforwarder.json
@@ -191,7 +191,7 @@
             "condition": "[variables('createActivityLogsDiagnosticSetting')]",
             "location": "[variables('location')]",
             "dependsOn": [
-                "[resourceId('Microsoft.EventHub/namespaces', variables('eventHubNamespaceName'))]"
+                "[resourceId('Microsoft.EventHub/namespaces/AuthorizationRules', variables('eventHubNamespaceName'), variables('logConsumerAuthorizationRuleName'))]"
             ],
             "properties": {
                 "rights": [


### PR DESCRIPTION
EventHubForwarder ARM Template fails to deploy when activating any of the ActivityLogs with a 409 Conflict when trying to create the consumer.

I'm not really aware of the reason, I'm assuming a race-condition with the producer.

Assuming it's a race condition trying to create both consumer and producer at the same time, I've added a `dependsOn` on the producer, so it will wait until the consumer is fully created. This way, the deployment works correctly.