### PR TITLE
Updates EventHubForwarder ARM template with secure settings

### DIFF
--- a/armTemplates/azuredeploy-eventhubforwarder.json
+++ b/armTemplates/azuredeploy-eventhubforwarder.json
@@ -207,7 +207,11 @@
             "sku": {
                 "name": "Standard_LRS"
             },
-            "kind": "StorageV2"
+            "kind": "StorageV2",
+            "properties": {
+                "publicNetworkAccess": "Disabled",
+                "allowBlobPublicAccess": false
+            }
         },
         {
             "type": "Microsoft.Web/serverfarms",
@@ -294,8 +298,11 @@
                             "name": "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING",
                             "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('storageAccountName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2021-04-01').keys[0].value,';EndpointSuffix=core.windows.net')]"
                         }
-                    ]
-                }
+                    ],
+                    "ftpsState": "Disabled",
+                    "publicNetworkAccess": "Disabled"
+                },
+                "httpsOnly": true
             }
         },
         {


### PR DESCRIPTION
The ARM template for the EventHubForwarder is currently missing some important security settings that expose our integration. Enabling them has been verified to not affect the normal operation of this log forwarding solution. These are:
- Disabling the public network access to the StorageAccount we create.
- Disabling public access to the blobs/containers in the StorageAccount we create.
- Disabling FTP access to the Microsoft.Web/sites executing our function.
- Enforcing HTTPS to the Microsoft.Web/sites executing our function.
- Disabling the public network access to the Microsoft.Web/sites executing our function.

This PR disables/enables these security settings. Please note that the publicNetworkAccess setting of the StorageAccount is currently being ignored by Azure, as mentioned in [this GH issue](https://github.com/MicrosoftDocs/azure-docs/issues/109354). Therefore, the user of this function will need to manually set it to "Disabled" once the StorageAccount has been created, here:

![Screenshot 2023-05-10 at 15 22 25](https://github.com/newrelic/newrelic-azure-functions/assets/6243832/48f42769-d009-458a-8948-863d25495748)
