### PR TITLE
Allow restricting public network access to Storage Account

### DIFF
--- a/armTemplates/azuredeploy-eventhubforwarder.json
+++ b/armTemplates/azuredeploy-eventhubforwarder.json
@@ -114,6 +114,13 @@
             "metadata": {
                 "description": "Contains the record of any service health incidents that have occurred in Azure. An example of a Service Health event SQL Azure in East US is experiencing downtime. Service Health events come in Six varieties: Action Required, Assisted Recovery, Incident, Maintenance, Information, or Security. These events are only created if you have a resource in the subscription that would be impacted by the event."
             }
+        },
+        "disablePublicAccessToStorageAccount": {
+            "type": "bool",
+            "defaultValue": false,
+            "metadata": {
+                "description": "Disables public network access to the Storage Account. As a consequence, communication with the Service Account will be performed through a private Virtual Network. Please note that due to this, the hosting pricing plan for the Function app server farm will need to be upgraded to 'Basic', as it is the minimum one providing VNet integration for Function apps (you can later upgrade this plan if you require more scaling options). Also note that the following extra resources will be created: a virtual network, a subnet, DNS zone names, virtual network links, private endpoints and a Storage Account file share."
+            }
         }
     },
     "variables": {
@@ -159,7 +166,7 @@
         "privateEndpointPrivateDnsZoneGroupsStorageTableName": "[format('{0}/{1}', variables('privateEndpointStorageTableName'), 'tablePrivateDnsZoneGroup')]",
         "privateEndpointPrivateDnsZoneGroupsStorageQueueName": "[format('{0}/{1}', variables('privateEndpointStorageQueueName'), 'queuePrivateDnsZoneGroup')]",
 
-        "functionContentShareName": "function-content-share",
+        "functionContentShareName": "[format('{0}-content-share', variables('functionAppName'))]",
         "storageAccountFileShareName": "[format('{0}/default/{1}', variables('storageAccountName'), variables('functionContentShareName'))]",
 
         "functionNetworkConfigName": "[format('{0}/{1}', variables('functionAppName'), 'virtualNetwork')]"
@@ -230,6 +237,7 @@
             }
         },
         {
+            "condition": "[parameters('disablePublicAccessToStorageAccount')]",
             "type": "Microsoft.Network/virtualNetworks",
             "apiVersion": "2022-09-01",
             "name": "[variables('virtualNetworkName')]",
@@ -269,30 +277,35 @@
             }
         },
         {
+            "condition": "[parameters('disablePublicAccessToStorageAccount')]",
             "type": "Microsoft.Network/privateDnsZones",
             "apiVersion": "2020-06-01",
             "name": "[variables('privateStorageFileDnsZoneName')]",
             "location": "global"
         },
         {
+            "condition": "[parameters('disablePublicAccessToStorageAccount')]",
             "type": "Microsoft.Network/privateDnsZones",
             "apiVersion": "2020-06-01",
             "name": "[variables('privateStorageBlobDnsZoneName')]",
             "location": "global"
         },
         {
+            "condition": "[parameters('disablePublicAccessToStorageAccount')]",
             "type": "Microsoft.Network/privateDnsZones",
             "apiVersion": "2020-06-01",
             "name": "[variables('privateStorageQueueDnsZoneName')]",
             "location": "global"
         },
         {
+            "condition": "[parameters('disablePublicAccessToStorageAccount')]",
             "type": "Microsoft.Network/privateDnsZones",
             "apiVersion": "2020-06-01",
             "name": "[variables('privateStorageTableDnsZoneName')]",
             "location": "global"
         },
         {
+            "condition": "[parameters('disablePublicAccessToStorageAccount')]",
             "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
             "apiVersion": "2020-06-01",
             "name": "[variables('privateStorageFileDnsZoneVirtualNetworkLinkName')]",
@@ -309,6 +322,7 @@
             }
         },
         {
+            "condition": "[parameters('disablePublicAccessToStorageAccount')]",
             "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
             "apiVersion": "2020-06-01",
             "name": "[variables('privateStorageBlobDnsZoneVirtualNetworkLinkName')]",
@@ -325,6 +339,7 @@
             }
         },
         {
+            "condition": "[parameters('disablePublicAccessToStorageAccount')]",
             "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
             "apiVersion": "2020-06-01",
             "name": "[variables('privateStorageQueueDnsZoneVirtualNetworkLinkName')]",
@@ -341,6 +356,7 @@
             }
         },
         {
+            "condition": "[parameters('disablePublicAccessToStorageAccount')]",
             "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
             "apiVersion": "2020-06-01",
             "name": "[variables('privateStorageTableDnsZoneVirtualNetworkLinkName')]",
@@ -357,6 +373,7 @@
             }
         },
         {
+            "condition": "[parameters('disablePublicAccessToStorageAccount')]",
             "type": "Microsoft.Network/privateEndpoints",
             "apiVersion": "2022-05-01",
             "name": "[variables('privateEndpointStorageFileName')]",
@@ -383,6 +400,7 @@
             }
         },
         {
+            "condition": "[parameters('disablePublicAccessToStorageAccount')]",
             "type": "Microsoft.Network/privateEndpoints",
             "apiVersion": "2022-05-01",
             "name": "[variables('privateEndpointStorageBlobName')]",
@@ -409,6 +427,7 @@
             }
         },
         {
+            "condition": "[parameters('disablePublicAccessToStorageAccount')]",
             "type": "Microsoft.Network/privateEndpoints",
             "apiVersion": "2022-05-01",
             "name": "[variables('privateEndpointStorageTableName')]",
@@ -435,6 +454,7 @@
             }
         },
         {
+            "condition": "[parameters('disablePublicAccessToStorageAccount')]",
             "type": "Microsoft.Network/privateEndpoints",
             "apiVersion": "2022-05-01",
             "name": "[variables('privateEndpointStorageQueueName')]",
@@ -461,6 +481,7 @@
             }
         },
         {
+            "condition": "[parameters('disablePublicAccessToStorageAccount')]",
             "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
             "apiVersion": "2022-05-01",
             "name": "[variables('privateEndpointPrivateDnsZoneGroupsStorageFileName')]",
@@ -480,6 +501,7 @@
             }
         },
         {
+            "condition": "[parameters('disablePublicAccessToStorageAccount')]",
             "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
             "apiVersion": "2022-05-01",
             "name": "[variables('privateEndpointPrivateDnsZoneGroupsStorageBlobName')]",
@@ -499,6 +521,7 @@
             }
         },
         {
+            "condition": "[parameters('disablePublicAccessToStorageAccount')]",
             "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
             "apiVersion": "2022-05-01",
             "name": "[variables('privateEndpointPrivateDnsZoneGroupsStorageTableName')]",
@@ -518,6 +541,7 @@
             }
         },
         {
+            "condition": "[parameters('disablePublicAccessToStorageAccount')]",
             "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
             "apiVersion": "2022-05-01",
             "name": "[variables('privateEndpointPrivateDnsZoneGroupsStorageQueueName')]",
@@ -546,15 +570,13 @@
             },
             "kind": "StorageV2",
             "properties": {
-                "publicNetworkAccess": "Disabled",
+                "publicNetworkAccess": "[if(parameters('disablePublicAccessToStorageAccount'), 'Disabled', 'Enabled')]",
                 "allowBlobPublicAccess": false,
-                "networkAcls": {
-                    "bypass": "None",
-                    "defaultAction": "Deny"
-                }
+                "networkAcls": "[if(parameters('disablePublicAccessToStorageAccount'), json('{\"bypass\": \"None\", \"defaultAction\": \"Deny\"}'), json('null'))]"
             }
         },
         {
+            "condition": "[parameters('disablePublicAccessToStorageAccount')]",
             "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
             "apiVersion": "2022-05-01",
             "name": "[variables('storageAccountFileShareName')]",
@@ -565,17 +587,11 @@
         {
             "type": "Microsoft.Web/serverfarms",
             "apiVersion": "2022-09-01",
-            "kind": "app",
+            "kind": "[if(parameters('disablePublicAccessToStorageAccount'), 'app', 'functionapp')]",
             "location": "[variables('location')]",
             "name": "[variables('servicePlanName')]",
-            "sku": {
-                "name": "B1",
-                "tier": "Basic",
-                "capacity": 1
-            },
-            "properties": {
-                "maximumElasticWorkerCount": 1
-            }
+            "sku": "[if(parameters('disablePublicAccessToStorageAccount'), json('{ \"name\":\"B1\", \"tier\": \"Basic\", \"capacity\": 1 }'), json('{ \"name\": \"Y1\", \"tier\": \"Dynamic\" }'))]",
+            "properties": "[ if(parameters('disablePublicAccessToStorageAccount'), json('{ \"maximumElasticWorkerCount\": 1 }'), json(concat('{ \"name\": \"', variables('servicePlanName'), '\", \"targetWorkerCount\": 1, \"targetWorkerSizeId\": 1, \"workerSize\": \"1\", \"numberOfWorkers\": 1, \"computeMode\": \"Dynamic\" }'))) ]"
         },
         {
             "type": "Microsoft.Web/sites",
@@ -658,21 +674,34 @@
                         },
                         {
                             "name": "WEBSITE_CONTENTOVERVNET",
-                            "value": "1"
+                            "value": "[if(parameters('disablePublicAccessToStorageAccount'), '1', '0')]"
                         },
                         {
                             "name": "WEBSITE_RUN_FROM_PACKAGE",
-                            "value": "[variables('eventHubForwarderFunctionArtifact')]"
+                            "value": "[if(parameters('disablePublicAccessToStorageAccount'), variables('eventHubForwarderFunctionArtifact'),'0')]"
                         }
                     ],
-                    "alwaysOn": true,
+                    "alwaysOn": "[parameters('disablePublicAccessToStorageAccount')]",
                     "ftpsState": "Disabled",
-                    "publicNetworkAccess": "Disabled"
+                    "publicNetworkAccess": "[if(parameters('disablePublicAccessToStorageAccount'), 'Disabled', 'Enabled')]"
                 },
                 "httpsOnly": true
             }
         },
         {
+            "condition": "[not(parameters('disablePublicAccessToStorageAccount'))]",
+            "type": "Microsoft.Web/sites/extensions",
+            "name": "[concat(variables('functionAppName'), '/ZipDeploy')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', variables('functionAppName'))]"
+            ],
+            "apiVersion": "2020-12-01",
+            "properties": {
+                "packageUri": "[variables('eventHubForwarderFunctionArtifact')]"
+            }
+        },
+        {
+            "condition": "[parameters('disablePublicAccessToStorageAccount')]",
             "type": "Microsoft.Web/sites/networkConfig",
             "apiVersion": "2022-03-01",
             "name": "[variables('functionNetworkConfigName')]",

--- a/armTemplates/azuredeploy-eventhubforwarder.json
+++ b/armTemplates/azuredeploy-eventhubforwarder.json
@@ -132,7 +132,37 @@
         "functionAppName": "[concat('nrlogs-eventhubforwarder-', variables('onePerResourceGroupAndEventHubUniqueSuffix'))]",
         "activityLogsDiagnosticSettingName": "[concat('nrlogs-activity-log-diagnostic-setting-', variables('onePerResourceGroupAndEventHubUniqueSuffix'))]",
         "createActivityLogsDiagnosticSetting": "[or(parameters('forwardAdministrativeAzureActivityLogs'), parameters('forwardAlertAzureActivityLogs'), parameters('forwardAutoscaleAzureActivityLogs'), parameters('forwardPolicyAzureActivityLogs'), parameters('forwardRecommendationAzureActivityLogs'), parameters('forwardResourceHealthAzureActivityLogs'), parameters('forwardSecurityAzureActivityLogs'), parameters('forwardServiceHealthAzureActivityLogs'))]",
-        "eventHubForwarderFunctionArtifact": "https://github.com/newrelic/newrelic-azure-functions/releases/latest/download/EventHubForwarder.zip"
+        "eventHubForwarderFunctionArtifact": "https://github.com/newrelic/newrelic-azure-functions/releases/latest/download/EventHubForwarder.zip",
+        
+        "virtualNetworkName": "[format('nrlogs{0}-virtual-network', variables('onePerResourceGroupUniqueSuffix'))]",
+        "functionSubnetName": "[format('{0}-internal-functions-subnet', variables('virtualNetworkName'))]",
+        "privateEndpointsSubnetName": "[format('{0}-private-endpoints-subnet', variables('virtualNetworkName'))]",
+
+        "dnsSuffix": "[environment().suffixes.storage]",
+        "privateStorageFileDnsZoneName": "[format('privatelink.file.{0}', variables('dnsSuffix'))]",
+        "privateStorageBlobDnsZoneName": "[format('privatelink.blob.{0}', variables('dnsSuffix'))]",
+        "privateStorageQueueDnsZoneName": "[format('privatelink.queue.{0}', variables('dnsSuffix'))]",
+        "privateStorageTableDnsZoneName": "[format('privatelink.table.{0}', variables('dnsSuffix'))]",
+
+        "privateStorageFileDnsZoneVirtualNetworkLinkName": "[format('{0}/{1}-link', variables('privateStorageFileDnsZoneName'), variables('virtualNetworkName'))]",
+        "privateStorageBlobDnsZoneVirtualNetworkLinkName": "[format('{0}/{1}-link', variables('privateStorageBlobDnsZoneName'), variables('virtualNetworkName'))]",
+        "privateStorageQueueDnsZoneVirtualNetworkLinkName": "[format('{0}/{1}-link', variables('privateStorageQueueDnsZoneName'), variables('virtualNetworkName'))]",
+        "privateStorageTableDnsZoneVirtualNetworkLinkName": "[format('{0}/{1}-link', variables('privateStorageTableDnsZoneName'), variables('virtualNetworkName'))]",
+
+        "privateEndpointStorageFileName": "[format('{0}-file-private-endpoint', variables('storageAccountName'))]",
+        "privateEndpointStorageTableName": "[format('{0}-table-private-endpoint', variables('storageAccountName'))]",
+        "privateEndpointStorageBlobName": "[format('{0}-blob-private-endpoint', variables('storageAccountName'))]",
+        "privateEndpointStorageQueueName": "[format('{0}-queue-private-endpoint', variables('storageAccountName'))]",
+
+        "privateEndpointPrivateDnsZoneGroupsStorageFileName": "[format('{0}/{1}', variables('privateEndpointStorageFileName'), 'filePrivateDnsZoneGroup')]",
+        "privateEndpointPrivateDnsZoneGroupsStorageBlobName": "[format('{0}/{1}', variables('privateEndpointStorageBlobName'), 'blobPrivateDnsZoneGroup')]",
+        "privateEndpointPrivateDnsZoneGroupsStorageTableName": "[format('{0}/{1}', variables('privateEndpointStorageTableName'), 'tablePrivateDnsZoneGroup')]",
+        "privateEndpointPrivateDnsZoneGroupsStorageQueueName": "[format('{0}/{1}', variables('privateEndpointStorageQueueName'), 'queuePrivateDnsZoneGroup')]",
+
+        "functionContentShareName": "function-content-share",
+        "storageAccountFileShareName": "[format('{0}/default/{1}', variables('storageAccountName'), variables('functionContentShareName'))]",
+
+        "functionNetworkConfigName": "[format('{0}/{1}', variables('functionAppName'), 'virtualNetwork')]"
     },
     "resources": [
         {
@@ -200,6 +230,313 @@
             }
         },
         {
+            "type": "Microsoft.Network/virtualNetworks",
+            "apiVersion": "2022-09-01",
+            "name": "[variables('virtualNetworkName')]",
+            "location": "[variables('location')]",
+            "properties": {
+                "addressSpace": {
+                    "addressPrefixes": [
+                        "10.2.0.0/16"
+                    ]
+                },
+                "subnets": [
+                    {
+                        "name": "[variables('functionSubnetName')]",
+                        "properties": {
+                            "privateEndpointNetworkPolicies": "Enabled",
+                            "privateLinkServiceNetworkPolicies": "Enabled",
+                            "delegations": [
+                            {
+                                "name": "webapp",
+                                "properties": {
+                                "serviceName": "Microsoft.Web/serverFarms"
+                                }
+                            }
+                            ],
+                            "addressPrefix": "10.2.0.0/24"
+                        }
+                    },
+                    {
+                        "name": "[variables('privateEndpointsSubnetName')]",
+                        "properties": {
+                            "privateEndpointNetworkPolicies": "Disabled",
+                            "privateLinkServiceNetworkPolicies": "Enabled",
+                            "addressPrefix": "10.2.1.0/24"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Microsoft.Network/privateDnsZones",
+            "apiVersion": "2020-06-01",
+            "name": "[variables('privateStorageFileDnsZoneName')]",
+            "location": "global"
+        },
+        {
+            "type": "Microsoft.Network/privateDnsZones",
+            "apiVersion": "2020-06-01",
+            "name": "[variables('privateStorageBlobDnsZoneName')]",
+            "location": "global"
+        },
+        {
+            "type": "Microsoft.Network/privateDnsZones",
+            "apiVersion": "2020-06-01",
+            "name": "[variables('privateStorageQueueDnsZoneName')]",
+            "location": "global"
+        },
+        {
+            "type": "Microsoft.Network/privateDnsZones",
+            "apiVersion": "2020-06-01",
+            "name": "[variables('privateStorageTableDnsZoneName')]",
+            "location": "global"
+        },
+        {
+            "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
+            "apiVersion": "2020-06-01",
+            "name": "[variables('privateStorageFileDnsZoneVirtualNetworkLinkName')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/privateDnsZones', variables('privateStorageFileDnsZoneName'))]",
+                "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]"
+            ],
+            "location": "global",
+            "properties": {
+                "registrationEnabled": false,
+                "virtualNetwork": {
+                    "id": "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
+            "apiVersion": "2020-06-01",
+            "name": "[variables('privateStorageBlobDnsZoneVirtualNetworkLinkName')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/privateDnsZones', variables('privateStorageBlobDnsZoneName'))]",
+                "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]"
+            ],
+            "location": "global",
+            "properties": {
+                "registrationEnabled": false,
+                "virtualNetwork": {
+                    "id": "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
+            "apiVersion": "2020-06-01",
+            "name": "[variables('privateStorageQueueDnsZoneVirtualNetworkLinkName')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/privateDnsZones', variables('privateStorageQueueDnsZoneName'))]",
+                "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]"
+            ],
+            "location": "global",
+            "properties": {
+                "registrationEnabled": false,
+                "virtualNetwork": {
+                    "id": "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
+            "apiVersion": "2020-06-01",
+            "name": "[variables('privateStorageTableDnsZoneVirtualNetworkLinkName')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/privateDnsZones', variables('privateStorageTableDnsZoneName'))]",
+                "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]"
+            ],
+            "location": "global",
+            "properties": {
+                "registrationEnabled": false,
+                "virtualNetwork": {
+                    "id": "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Network/privateEndpoints",
+            "apiVersion": "2022-05-01",
+            "name": "[variables('privateEndpointStorageFileName')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]",
+                "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]"
+            ],
+            "location": "[variables('location')]",
+            "properties": {
+                "subnet": {
+                    "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('privateEndpointsSubnetName'))]"
+                },
+                "privateLinkServiceConnections": [
+                    {
+                        "name": "MyStorageFilePrivateLinkConnection",
+                        "properties": {
+                            "privateLinkServiceId": "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]",
+                            "groupIds": [
+                                "file"
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Microsoft.Network/privateEndpoints",
+            "apiVersion": "2022-05-01",
+            "name": "[variables('privateEndpointStorageBlobName')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]",
+                "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]"
+            ],
+            "location": "[variables('location')]",
+            "properties": {
+                "subnet": {
+                    "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('privateEndpointsSubnetName'))]"
+                },
+                "privateLinkServiceConnections": [
+                    {
+                        "name": "MyStorageBlobPrivateLinkConnection",
+                        "properties": {
+                            "privateLinkServiceId": "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]",
+                            "groupIds": [
+                                "blob"
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Microsoft.Network/privateEndpoints",
+            "apiVersion": "2022-05-01",
+            "name": "[variables('privateEndpointStorageTableName')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]",
+                "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]"
+            ],
+            "location": "[variables('location')]",
+            "properties": {
+                "subnet": {
+                    "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('privateEndpointsSubnetName'))]"
+                },
+                "privateLinkServiceConnections": [
+                    {
+                        "name": "MyStorageTablePrivateLinkConnection",
+                        "properties": {
+                            "privateLinkServiceId": "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]",
+                            "groupIds": [
+                                "table"
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Microsoft.Network/privateEndpoints",
+            "apiVersion": "2022-05-01",
+            "name": "[variables('privateEndpointStorageQueueName')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]",
+                "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]"
+            ],
+            "location": "[variables('location')]",
+            "properties": {
+                "subnet": {
+                    "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('privateEndpointsSubnetName'))]"
+                },
+                "privateLinkServiceConnections": [
+                    {
+                        "name": "MyStorageQueuePrivateLinkConnection",
+                        "properties": {
+                            "privateLinkServiceId": "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]",
+                            "groupIds": [
+                                "queue"
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
+            "apiVersion": "2022-05-01",
+            "name": "[variables('privateEndpointPrivateDnsZoneGroupsStorageFileName')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/privateEndpoints', variables('privateEndpointStorageFileName'))]",
+                "[resourceId('Microsoft.Network/privateDnsZones', variables('privateStorageFileDnsZoneName'))]"
+            ],
+            "properties": {
+                "privateDnsZoneConfigs": [
+                    {
+                        "name": "config",
+                        "properties": {
+                            "privateDnsZoneId": "[resourceId('Microsoft.Network/privateDnsZones', variables('privateStorageFileDnsZoneName'))]"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
+            "apiVersion": "2022-05-01",
+            "name": "[variables('privateEndpointPrivateDnsZoneGroupsStorageBlobName')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/privateEndpoints', variables('privateEndpointStorageBlobName'))]",
+                "[resourceId('Microsoft.Network/privateDnsZones', variables('privateStorageBlobDnsZoneName'))]"
+            ],
+            "properties": {
+                "privateDnsZoneConfigs": [
+                    {
+                        "name": "config",
+                        "properties": {
+                            "privateDnsZoneId": "[resourceId('Microsoft.Network/privateDnsZones', variables('privateStorageBlobDnsZoneName'))]"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
+            "apiVersion": "2022-05-01",
+            "name": "[variables('privateEndpointPrivateDnsZoneGroupsStorageTableName')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/privateEndpoints', variables('privateEndpointStorageTableName'))]",
+                "[resourceId('Microsoft.Network/privateDnsZones', variables('privateStorageTableDnsZoneName'))]"
+            ],
+            "properties": {
+                "privateDnsZoneConfigs": [
+                    {
+                        "name": "config",
+                        "properties": {
+                            "privateDnsZoneId": "[resourceId('Microsoft.Network/privateDnsZones', variables('privateStorageTableDnsZoneName'))]"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
+            "apiVersion": "2022-05-01",
+            "name": "[variables('privateEndpointPrivateDnsZoneGroupsStorageQueueName')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/privateEndpoints', variables('privateEndpointStorageQueueName'))]",
+                "[resourceId('Microsoft.Network/privateDnsZones', variables('privateStorageQueueDnsZoneName'))]"
+            ],
+            "properties": {
+                "privateDnsZoneConfigs": [
+                    {
+                        "name": "config",
+                        "properties": {
+                            "privateDnsZoneId": "[resourceId('Microsoft.Network/privateDnsZones', variables('privateStorageQueueDnsZoneName'))]"
+                        }
+                    }
+                ]
+            }
+        },
+        {
             "type": "Microsoft.Storage/storageAccounts",
             "apiVersion": "2021-04-01",
             "name": "[variables('storageAccountName')]",
@@ -210,26 +547,34 @@
             "kind": "StorageV2",
             "properties": {
                 "publicNetworkAccess": "Disabled",
-                "allowBlobPublicAccess": false
+                "allowBlobPublicAccess": false,
+                "networkAcls": {
+                    "bypass": "None",
+                    "defaultAction": "Deny"
+                }
             }
         },
         {
+            "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
+            "apiVersion": "2022-05-01",
+            "name": "[variables('storageAccountFileShareName')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
+            ]
+        },
+        {
             "type": "Microsoft.Web/serverfarms",
-            "apiVersion": "2020-06-01",
-            "kind": "functionapp",
+            "apiVersion": "2022-09-01",
+            "kind": "app",
             "location": "[variables('location')]",
             "name": "[variables('servicePlanName')]",
-            "properties": {
-                "name": "[variables('servicePlanName')]",
-                "targetWorkerCount": 1,
-                "targetWorkerSizeId": 1,
-                "workerSize": "1",
-                "numberOfWorkers": 1,
-                "computeMode": "Dynamic"
-            },
             "sku": {
-                "name": "Y1",
-                "tier": "Dynamic"
+                "name": "B1",
+                "tier": "Basic",
+                "capacity": 1
+            },
+            "properties": {
+                "maximumElasticWorkerCount": 1
             }
         },
         {
@@ -240,7 +585,16 @@
             "kind": "functionapp",
             "dependsOn": [
                 "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]",
-                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
+                "[resourceId('Microsoft.Network/privateEndpoints/privateDnsZoneGroups', variables('privateEndpointStorageBlobName'), 'blobPrivateDnsZoneGroup')]",
+                "[resourceId('Microsoft.Network/privateEndpoints/privateDnsZoneGroups', variables('privateEndpointStorageFileName'), 'filePrivateDnsZoneGroup')]",
+                "[resourceId('Microsoft.Network/privateEndpoints/privateDnsZoneGroups', variables('privateEndpointStorageQueueName'), 'queuePrivateDnsZoneGroup')]",
+                "[resourceId('Microsoft.Network/privateEndpoints/privateDnsZoneGroups', variables('privateEndpointStorageTableName'), 'tablePrivateDnsZoneGroup')]",
+                "[resourceId('Microsoft.Network/privateDnsZones/virtualNetworkLinks', variables('privateStorageBlobDnsZoneName'), format('{0}-link', variables('virtualNetworkName')))]",
+                "[resourceId('Microsoft.Network/privateDnsZones/virtualNetworkLinks', variables('privateStorageFileDnsZoneName'), format('{0}-link', variables('virtualNetworkName')))]",
+                "[resourceId('Microsoft.Network/privateDnsZones/virtualNetworkLinks', variables('privateStorageQueueDnsZoneName'), format('{0}-link', variables('virtualNetworkName')))]",
+                "[resourceId('Microsoft.Network/privateDnsZones/virtualNetworkLinks', variables('privateStorageTableDnsZoneName'), format('{0}-link', variables('virtualNetworkName')))]",
+                "[resourceId('Microsoft.Storage/storageAccounts/fileServices/shares', variables('storageAccountName'), 'default', variables('functionContentShareName'))]"
             ],
             "properties": {
                 "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
@@ -292,13 +646,26 @@
                         },
                         {
                             "name": "AzureWebJobsStorage",
-                            "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('storageAccountName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2021-04-01').keys[0].value,';EndpointSuffix=core.windows.net')]"
+                            "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('storageAccountName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2021-04-01').keys[0].value,';EndpointSuffix=',environment().suffixes.storage)]"
                         },
                         {
                             "name": "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING",
-                            "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('storageAccountName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2021-04-01').keys[0].value,';EndpointSuffix=core.windows.net')]"
+                            "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('storageAccountName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2021-04-01').keys[0].value,';EndpointSuffix=',environment().suffixes.storage)]"
+                        },
+                        {
+                            "name": "WEBSITE_CONTENTSHARE",
+                            "value": "[variables('functionContentShareName')]"
+                        },
+                        {
+                            "name": "WEBSITE_CONTENTOVERVNET",
+                            "value": "1"
+                        },
+                        {
+                            "name": "WEBSITE_RUN_FROM_PACKAGE",
+                            "value": "[variables('eventHubForwarderFunctionArtifact')]"
                         }
                     ],
+                    "alwaysOn": true,
                     "ftpsState": "Disabled",
                     "publicNetworkAccess": "Disabled"
                 },
@@ -306,14 +673,16 @@
             }
         },
         {
-            "type": "Microsoft.Web/sites/extensions",
-            "name": "[concat(variables('functionAppName'), '/ZipDeploy')]",
+            "type": "Microsoft.Web/sites/networkConfig",
+            "apiVersion": "2022-03-01",
+            "name": "[variables('functionNetworkConfigName')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/sites', variables('functionAppName'))]"
+                "[resourceId('Microsoft.Web/sites', variables('functionAppName'))]",
+                "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]"
             ],
-            "apiVersion": "2020-12-01",
             "properties": {
-                "packageUri": "[variables('eventHubForwarderFunctionArtifact')]"
+                "subnetResourceId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('functionSubnetName'))]",
+                "swiftSupported": true
             }
         },
         {


### PR DESCRIPTION
## Description
This PR allows blocking public network access to the Storage Account our EventHubForwarder ARM template creates based on the newly introduced `disablePublicAccessToStorageAccount` parameter.

## Change summary

Disabling public network access in a Storage Account has several effects on the deployment and wiring of a Function App. It involves creating private endpoints in private networks, enabling the VNet integration for Function Apps (which forces a pricing plan upgrade) and creating several DNS A records to ensure that the Storage Account is reachable by the Function App using its new private interfaces instead of the public one (more details below). This is why we have added this as an opt-in feature by using the `disablePublicAccessToStorageAccount` parameter:

![Screenshot 2023-05-12 at 13 54 30](https://github.com/newrelic/newrelic-azure-functions/assets/6243832/e608097b-5436-4752-b206-437ab336e858)

We have based our changes on the excellent Azure quickstart template from [this page](https://learn.microsoft.com/en-us/samples/azure/azure-quickstart-templates/function-app-storage-private-endpoints/). A user with an existing installation could attempt to migrate it to a private-based one following the steps mentioned in [this blogpost](https://techcommunity.microsoft.com/t5/apps-on-azure-blog/secure-storage-account-linked-to-function-app-with-private/ba-p/2644772). Nevertheless, due to the complexity of such changes and how easy it is to make mistakes, our recommendation would be to reinstall our integration from scratch using the now upgraded [EventHubForwarder ARM template](https://github.com/newrelic/newrelic-azure-functions/blob/master/armTemplates/azuredeploy-eventhubforwarder.json).

## Change details

![image](https://github.com/newrelic/newrelic-azure-functions/assets/6243832/8f67cda7-651e-4b33-b71b-0809f1652cdd)

(image taken from [this page](https://learn.microsoft.com/en-us/samples/azure/azure-quickstart-templates/function-app-storage-private-endpoints/))

Function Apps require a Storage Account for them to work, as explained in [these docs](https://learn.microsoft.com/en-us/azure/azure-functions/storage-considerations?tabs=azure-cli#storage-account-requirements). In particular, they need to access to the Azure Blob Storage, Files, Queue Storage and Table Storage services provided by the Service Account. They access these services using the DNS of these services Storage Account (they have the form `<storage_account_name>.[file/blob/table/queue].core.windows.net`), which resolve to the Storage Account public IP address. So, we have this DNS resolution:

(several DNS record chain): `<storage_account_name>.[file/blob/table/queue].core.windows.net` --> public IP address of Storage Account

Nevertheless, when public network access is restricted, this public IP address is inaccessible and we need to create private endpoints (virtual private IP addresses) inside a virtual private network (VNet) and attach them via private links (virtual network interfaces) to the Storage Account. Also, when public network access is disabled and private endpoints are enabled in the Storage Account, Azure changes the DNS resolution to point to a privatelink endpoint, and we need to create a DNS A record to point that privatelink endpoint to the private endpoint (private IP address) of the Storage Account (this is my understanding from reading [this article](https://learn.microsoft.com/en-us/azure/app-service/networking/private-endpoint#dns ):

This is what Azure sets:
- CNAME record: `<storage_account_name>.[file/blob/table/queue].core.windows.net` --> `<storage_account_name>.[file/blob/table/queue].privatelink.core.windows.net`

This is what we need to add so the address is resolved to the private interface:
- A record: `<storage_account_name>.[file/blob/table/queue].privatelink.core.windows.net` --> 10.2.0.3

To achieve this, we need to also create DNS zone for each storage service, with a corresponding private endpoint, and we will create a DNS A record to point to the private IP address associated with the private endpoint.

For our Function App to be able to use the VNet integration, we need to upgrade its pricing model from the current Consumption-based (serverless) to a Dedicated (App Service) or Elastic Premium plans, as mentioned in [the docs](https://learn.microsoft.com/en-us/azure/azure-functions/configure-networking-how-to?tabs=portal#restrict-your-storage-account-to-a-virtual-network:~:text=Securing%20your%20storage%20account%20is%20supported%20for%20all%20tiers%20in%20both%20Dedicated%20(App%20Service)%20and%20Elastic%20Premium%20plans.%20Consumption%20plans%20currently%20don%27t%20support%20virtual%20networks.). We have chosen the Basic App Service pricing plan in order to incur the lowest costs on the user end. But if a user needs to scale their log forwarder due to having a great log volume, they can do so after deploying the EvetHubForwarder ARM template by upgrading their pricing plan in the Server Farm that we deploy. 

We have also enabled the application to be run from a package instead of using ZipDeploy by using [these instructions](https://learn.microsoft.com/en-us/azure/azure-functions/run-functions-from-deployment-package). This change was needed since [we have restricted the network access to the Function App](https://learn.microsoft.com/en-us/azure/app-service/networking/private-endpoint#dns:~:text=When%20you%20enable%20private%20endpoints%20to%20your%20app%2C%20ensure%20that%20public%20network%20access%20is%20disabled%20to%20ensure%20isolation.) as well.