### PR TITLE
Fix bug in Azure Function App ARM when using Blob Storage

### DIFF
--- a/armTemplates/azuredeploy-blobforwarder.json
+++ b/armTemplates/azuredeploy-blobforwarder.json
@@ -542,10 +542,10 @@
               }
             ],
             "alwaysOn": "[parameters('disablePublicAccessToStorageAccount')]",
-            "ftpsState": "Disabled",
-            "publicNetworkAccess": "[if(parameters('disablePublicAccessToStorageAccount'), 'Disabled', 'Enabled')]"
+            "ftpsState": "Disabled"
         },
-        "httpsOnly": true
+        "httpsOnly": true,
+        "publicNetworkAccess": "[if(parameters('disablePublicAccessToStorageAccount'), 'Disabled', 'Enabled')]"
       }
     },
     {


### PR DESCRIPTION
### Description

This PR fixes a bug that causes the provisioning of the Azure Function App that is used to forward the logs from a Storage Account to New Relic to fail.

### Change details

Moved the PublicNetworkAccess property from SiteConfig.PublicNetworkAccess to Site.PublicNetworkAccess.

### Error details

To reproduce the error, follow the instructions for [Deploying the New Relic Blob Storage ARM template](https://docs.newrelic.com/docs/logs/forward-logs/azure-log-forwarding/#blobstorage-arm-setup).  
The ARM template fails to deploy the Function App with the error:  

_There was a conflict. SiteConfig.PublicNetworkAccess cannot be set by itself. Please use the Site.PublicNetworkAccess property._  
_(Target: [azure_resource_identifier])_