### PR TITLE
Node 20 upgrade

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,10 +8,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Use Node.js 16.x
+    - name: Use Node.js 20.x
       uses: actions/setup-node@v1
       with:
-        node-version: 16.x
+        node-version: 20.x
     - name: Install Dependencies
       run: npm ci
     - name: Run Linting
@@ -21,10 +21,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Use Node.js 16.x
+    - name: Use Node.js 20.x
       uses: actions/setup-node@v1
       with:
-        node-version: 16.x
+        node-version: 20.x
     - name: Install Dependencies
       run: npm ci
     - name: Run Unit test cases

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 16.x
+          node-version: 20.x
 
       - name: Cache node_modules
         id: cache-node-modules
@@ -135,7 +135,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 16.x
+          node-version: 20.x
 
       - name: Download Cached Deps
         id: cache-node-modules

--- a/armTemplates/azuredeploy-blobforwarder.json
+++ b/armTemplates/azuredeploy-blobforwarder.json
@@ -522,7 +522,7 @@
               },
               {
                 "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                "value": "~16"
+                "value": "~20"
               },
               {
                 "name": "FUNCTIONS_EXTENSION_VERSION",

--- a/armTemplates/azuredeploy-eventhubforwarder.json
+++ b/armTemplates/azuredeploy-eventhubforwarder.json
@@ -658,7 +658,7 @@
                         },
                         {
                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                            "value": "~16"
+                            "value": "~20"
                         },
                         {
                             "name": "AzureWebJobsStorage",


### PR DESCRIPTION
Upgrading Node versions on ARM Templates and Github Actions (PR tests etc) to 20.

Node 16 is deprecated.