### PR TITLE
Removes Content Share when using private Storage Account connectivity

### DIFF
--- a/armTemplates/azuredeploy-blobforwarder.json
+++ b/armTemplates/azuredeploy-blobforwarder.json
@@ -98,9 +98,6 @@
     "privateEndpointPrivateDnsZoneGroupsStorageTableName": "[format('{0}/{1}', variables('privateEndpointStorageTableName'), 'tablePrivateDnsZoneGroup')]",
     "privateEndpointPrivateDnsZoneGroupsStorageQueueName": "[format('{0}/{1}', variables('privateEndpointStorageQueueName'), 'queuePrivateDnsZoneGroup')]",
 
-    "functionContentShareName": "[format('{0}-content-share', variables('functionAppName'))]",
-    "storageAccountFileShareName": "[format('{0}/default/{1}', variables('internalStorageAccountName'), variables('functionContentShareName'))]",
-
     "functionNetworkConfigName": "[format('{0}/{1}', variables('functionAppName'), 'virtualNetwork')]"
   },
   "resources": [
@@ -444,15 +441,6 @@
         }
     },
     {
-        "condition": "[parameters('disablePublicAccessToStorageAccount')]",
-        "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
-        "apiVersion": "2022-05-01",
-        "name": "[variables('storageAccountFileShareName')]",
-        "dependsOn": [
-            "[resourceId('Microsoft.Storage/storageAccounts', variables('internalStorageAccountName'))]"
-        ]
-    },
-    {
         "type": "Microsoft.Web/serverfarms",
         "apiVersion": "2022-09-01",
         "kind": "[if(parameters('disablePublicAccessToStorageAccount'), 'app', 'functionapp')]",
@@ -477,8 +465,7 @@
             "[resourceId('Microsoft.Network/privateDnsZones/virtualNetworkLinks', variables('privateStorageBlobDnsZoneName'), format('{0}-link', variables('virtualNetworkName')))]",
             "[resourceId('Microsoft.Network/privateDnsZones/virtualNetworkLinks', variables('privateStorageFileDnsZoneName'), format('{0}-link', variables('virtualNetworkName')))]",
             "[resourceId('Microsoft.Network/privateDnsZones/virtualNetworkLinks', variables('privateStorageQueueDnsZoneName'), format('{0}-link', variables('virtualNetworkName')))]",
-            "[resourceId('Microsoft.Network/privateDnsZones/virtualNetworkLinks', variables('privateStorageTableDnsZoneName'), format('{0}-link', variables('virtualNetworkName')))]",
-            "[resourceId('Microsoft.Storage/storageAccounts/fileServices/shares', variables('internalStorageAccountName'), 'default', variables('functionContentShareName'))]"
+            "[resourceId('Microsoft.Network/privateDnsZones/virtualNetworkLinks', variables('privateStorageTableDnsZoneName'), format('{0}-link', variables('virtualNetworkName')))]"
         ],
         "properties": {
           "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
@@ -513,10 +500,6 @@
                 "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('internalStorageAccountName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('internalStorageAccountName')), '2021-04-01').keys[0].value,';EndpointSuffix=',environment().suffixes.storage)]"
               },
               {
-                "name": "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING",
-                "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('internalStorageAccountName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('internalStorageAccountName')), '2021-04-01').keys[0].value,';EndpointSuffix=',environment().suffixes.storage)]"
-              },
-              {
                 "name": "FUNCTIONS_WORKER_RUNTIME",
                 "value": "node"
               },
@@ -527,14 +510,6 @@
               {
                 "name": "FUNCTIONS_EXTENSION_VERSION",
                 "value": "~4"
-              },
-              {
-                "name": "WEBSITE_CONTENTSHARE",
-                "value": "[variables('functionContentShareName')]"
-              },
-              {
-                "name": "WEBSITE_CONTENTOVERVNET",
-                "value": "[if(parameters('disablePublicAccessToStorageAccount'), '1', '0')]"
               },
               {
                 "name": "WEBSITE_RUN_FROM_PACKAGE",

--- a/armTemplates/azuredeploy-blobforwarder.json
+++ b/armTemplates/azuredeploy-blobforwarder.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-  "contentVersion": "1.0.0.0",
+  "contentVersion": "1.1.0.0",
   "parameters": {
     "newRelicLicenseKey": {
       "type": "string",

--- a/armTemplates/azuredeploy-eventhubforwarder.json
+++ b/armTemplates/azuredeploy-eventhubforwarder.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
+    "contentVersion": "1.1.0.0",
     "parameters": {
         "newRelicLicenseKey": {
             "type": "string",
@@ -12,7 +12,7 @@
             "type": "string",
             "defaultValue": "",
             "metadata": {
-                "description": "Event Hub Namespace where all logs to be forwarded to New Relic are being sent to. Leave this blank for a new namespace to be created automatically (its name will start with 'nrlogs-')."
+                "description": "Event Hub Namespace https://docs.newrelic.com/docs/logs/forward-logs/azure-log-forwarding/where all logs to be forwarded to New Relic are being sent to. Leave this blank for a new namespace to be created automatically (its name will start with 'nrlogs-')."
             }
         },
         "eventHubName": {

--- a/armTemplates/azuredeploy-eventhubforwarder.json
+++ b/armTemplates/azuredeploy-eventhubforwarder.json
@@ -12,7 +12,7 @@
             "type": "string",
             "defaultValue": "",
             "metadata": {
-                "description": "Event Hub Namespace https://docs.newrelic.com/docs/logs/forward-logs/azure-log-forwarding/where all logs to be forwarded to New Relic are being sent to. Leave this blank for a new namespace to be created automatically (its name will start with 'nrlogs-')."
+                "description": "Event Hub Namespace where all logs to be forwarded to New Relic are being sent to. Leave this blank for a new namespace to be created automatically (its name will start with 'nrlogs-')."
             }
         },
         "eventHubName": {

--- a/armTemplates/azuredeploy-eventhubforwarder.json
+++ b/armTemplates/azuredeploy-eventhubforwarder.json
@@ -166,9 +166,6 @@
         "privateEndpointPrivateDnsZoneGroupsStorageTableName": "[format('{0}/{1}', variables('privateEndpointStorageTableName'), 'tablePrivateDnsZoneGroup')]",
         "privateEndpointPrivateDnsZoneGroupsStorageQueueName": "[format('{0}/{1}', variables('privateEndpointStorageQueueName'), 'queuePrivateDnsZoneGroup')]",
 
-        "functionContentShareName": "[format('{0}-content-share', variables('functionAppName'))]",
-        "storageAccountFileShareName": "[format('{0}/default/{1}', variables('storageAccountName'), variables('functionContentShareName'))]",
-
         "functionNetworkConfigName": "[format('{0}/{1}', variables('functionAppName'), 'virtualNetwork')]"
     },
     "resources": [
@@ -576,15 +573,6 @@
             }
         },
         {
-            "condition": "[parameters('disablePublicAccessToStorageAccount')]",
-            "type": "Microsoft.Storage/storageAccounts/fileServices/shares",
-            "apiVersion": "2022-05-01",
-            "name": "[variables('storageAccountFileShareName')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
-            ]
-        },
-        {
             "type": "Microsoft.Web/serverfarms",
             "apiVersion": "2022-09-01",
             "kind": "[if(parameters('disablePublicAccessToStorageAccount'), 'app', 'functionapp')]",
@@ -609,8 +597,7 @@
                 "[resourceId('Microsoft.Network/privateDnsZones/virtualNetworkLinks', variables('privateStorageBlobDnsZoneName'), format('{0}-link', variables('virtualNetworkName')))]",
                 "[resourceId('Microsoft.Network/privateDnsZones/virtualNetworkLinks', variables('privateStorageFileDnsZoneName'), format('{0}-link', variables('virtualNetworkName')))]",
                 "[resourceId('Microsoft.Network/privateDnsZones/virtualNetworkLinks', variables('privateStorageQueueDnsZoneName'), format('{0}-link', variables('virtualNetworkName')))]",
-                "[resourceId('Microsoft.Network/privateDnsZones/virtualNetworkLinks', variables('privateStorageTableDnsZoneName'), format('{0}-link', variables('virtualNetworkName')))]",
-                "[resourceId('Microsoft.Storage/storageAccounts/fileServices/shares', variables('storageAccountName'), 'default', variables('functionContentShareName'))]"
+                "[resourceId('Microsoft.Network/privateDnsZones/virtualNetworkLinks', variables('privateStorageTableDnsZoneName'), format('{0}-link', variables('virtualNetworkName')))]"
             ],
             "properties": {
                 "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
@@ -663,18 +650,6 @@
                         {
                             "name": "AzureWebJobsStorage",
                             "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('storageAccountName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2021-04-01').keys[0].value,';EndpointSuffix=',environment().suffixes.storage)]"
-                        },
-                        {
-                            "name": "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING",
-                            "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('storageAccountName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2021-04-01').keys[0].value,';EndpointSuffix=',environment().suffixes.storage)]"
-                        },
-                        {
-                            "name": "WEBSITE_CONTENTSHARE",
-                            "value": "[variables('functionContentShareName')]"
-                        },
-                        {
-                            "name": "WEBSITE_CONTENTOVERVNET",
-                            "value": "[if(parameters('disablePublicAccessToStorageAccount'), '1', '0')]"
                         },
                         {
                             "name": "WEBSITE_RUN_FROM_PACKAGE",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newrelic-azure-functions",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "This repository contains functions to collect and forward logs from Microsoft Azure Blob Storage and Event Hubs.",
   "scripts": {
     "lint": "eslint ./**/*.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newrelic-azure-functions",
-  "version": "2.6.0",
+  "version": "2.5.1",
   "description": "This repository contains functions to collect and forward logs from Microsoft Azure Blob Storage and Event Hubs.",
   "scripts": {
     "lint": "eslint ./**/*.js",


### PR DESCRIPTION
# Description
Back in May 2023, we modified our [EventHub](https://github.com/newrelic/newrelic-azure-functions/pull/80) and [BlobStorage](https://github.com/newrelic/newrelic-azure-functions/pull/83) ARM templates to allow having private connectivity only between the Function App and the Storage Account they use to store the data required by these function to work. They have been working fine since then. However, the deployment of such functions started being faulty some time ago.

We engaged into an investigation with the Azure engineers, with whom we found out that some change was introduced in the Azure Platform that arises a race condition. This race condition causes the Function App to start before the VNET is fully configured. The function app then tries to reach the Storage Account through the Azure backbone network instead of the VNET (thus attempting to reach it via its public endpoint). Because the Storage Account has public connectivity disabled, this connection is refused and prevents the function from even being able to deploy its own code in the Content Share it used.

We determined this race condition is intermitent (sometimes the function just works, sometimes it just doesn't). Restarting the function sometimes resets the configuration so that the function starts using the VNET to access the storage account. 

Nevertheless, given that this is totally random, the Azure engineers suggested we mitigate this by not using a content share in the Storage Account to deploy the function code into. Given that our function (when deployed with private connectivity only) runs on a dedicated plan, using a content share is not necessary since the functions end up using platform-provided built-in storage. That is, the function code gets deployed inside the VM that executes our function instead of using the Storage Account content share.

# Changes
- This PR doesn't alter at all the functionality of the forwarding functions. 
- Removes the creation of the Content Share and their references in the Function App when using private connectivity.