### PR TITLE
Force using OpenSource Bot's token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+        with:
+          # Avoid using GITHUB_TOKEN, instead of the Open Source Bot personal access token.
+          persist-credentials: false
 
       # Probably not necessary since the ubuntu-latest image would have latest Node LTS release
       # and nothing in this job _needs_ older Node
@@ -85,11 +88,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: [job-generate-third-party-notices]
     steps:
-      # Checkout ref: master because previous job committed third_party_notices and
-      # we need to checkout master to pick up that commit
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
+          # Avoid using GITHUB_TOKEN, instead of the Open Source Bot personal access token.
+          persist-credentials: false
+          # Checkout ref: master because previous job committed third_party_notices and
+          # we need to checkout master to pick up that commit
           ref: master
 
       - name: Setup Node.js


### PR DESCRIPTION
It seems the checkout actions cause that the subsequent pushes use the GITHUB_TOKEN instead of the OPENSOURCE_BOT_TOKEN. Reference: https://github.com/ad-m/github-push-action?tab=readme-ov-file#example-workflow-file
