### PR TITLE
fix: update JP region endpoint to log-api.jp.nr-data.net/log/v1

### DIFF
--- a/LogForwarder/BlobForwarder/README.md
+++ b/LogForwarder/BlobForwarder/README.md
@@ -47,7 +47,7 @@ Parameters that can be configured in your Azure Resource Manager Template
 | Target Storage Account Name | yes | `none` | Name of the existing Azure Storage Account that contains the logs you want to forward. |
 | Target Container Name | yes | `none` | Name of the container inside the target Storage Account that contains the log blobs. |
 | Location | no | Resource group location | Region where the Function App and associated resources will be deployed. Defaults to the resource group's location. |
-| New Relic Endpoint  |  no | `https://log-api.newrelic.com/log/v1` | New Relic Logs [ingestion endpoint](https://docs.newrelic.com/docs/logs/log-api/introduction-log-api/#endpoint). Use `https://log-api.newrelic.com/log/v1` for US, `https://log-api.eu.newrelic.com/log/v1` for EU, or `https://log-api.jp.newrelic.com/log/v1` for JP region |
+| New Relic Endpoint  |  no | `https://log-api.newrelic.com/log/v1` | New Relic Logs [ingestion endpoint](https://docs.newrelic.com/docs/logs/log-api/introduction-log-api/#endpoint). Use `https://log-api.newrelic.com/log/v1` for US, `https://log-api.eu.newrelic.com/log/v1` for EU, or `https://log-api.jp.nr-data.net/log/v1` for JP region |
 | Max Retries To Resend Logs  | no | `3` | Number of times the function will attempt to resend data if there's a failure. |
 | Retry Interval  | no | `2000` | Interval between retry attempts in milliseconds. |
 | Disable Public Access To Storage Account | no | `false` | When set to `true`, disables public network access to the internal storage account used by the Function App. This creates a private network deployment with VNet integration, private endpoints, private DNS zones, and requires a Basic hosting plan or higher. When `false`, uses App Service plan with public access. |
@@ -199,7 +199,7 @@ Azure Functions v4 uses a package deployment model. Code cannot be edited direct
 
 | Name | Default Value | Description |
 |------|---------------|-------------|
-| `NR_ENDPOINT` | `https://log-api.newrelic.com/log/v1` | New Relic Logs API endpoint. Use `https://log-api.newrelic.com/log/v1` for US, `https://log-api.eu.newrelic.com/log/v1` for EU, or `https://log-api.jp.newrelic.com/log/v1` for JP region |
+| `NR_ENDPOINT` | `https://log-api.newrelic.com/log/v1` | New Relic Logs API endpoint. Use `https://log-api.newrelic.com/log/v1` for US, `https://log-api.eu.newrelic.com/log/v1` for EU, or `https://log-api.jp.nr-data.net/log/v1` for JP region |
 | `NR_TAGS` | _(empty)_ | Custom attributes to add to all forwarded logs. Semicolon-delimited format: `env:prod;team:platform;app:myapp` |
 | `NR_MAX_RETRIES` | `3` | Number of retry attempts if sending logs to New Relic fails. |
 | `NR_RETRY_INTERVAL` | `2000` | Milliseconds to wait between retry attempts. |

--- a/LogForwarder/EventHubForwarder/README.md
+++ b/LogForwarder/EventHubForwarder/README.md
@@ -47,7 +47,7 @@ Parameters that can be configured in your Azure Resource Manager Template
 |---|---|---|---|
 | New Relic License Key  | yes | `none` | Your New Relic [License key](https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/#license-key). |
 | Location | no | Resource group location | Region where the Function App and associated resources will be deployed. Defaults to the resource group's location. |
-| New Relic Endpoint  |  no | `https://log-api.newrelic.com/log/v1` | New Relic Logs [ingestion endpoint](https://docs.newrelic.com/docs/logs/log-api/introduction-log-api/#endpoint). Use `https://log-api.newrelic.com/log/v1` for US, `https://log-api.eu.newrelic.com/log/v1` for EU, or `https://log-api.jp.newrelic.com/log/v1` for JP region |
+| New Relic Endpoint  |  no | `https://log-api.newrelic.com/log/v1` | New Relic Logs [ingestion endpoint](https://docs.newrelic.com/docs/logs/log-api/introduction-log-api/#endpoint). Use `https://log-api.newrelic.com/log/v1` for US, `https://log-api.eu.newrelic.com/log/v1` for EU, or `https://log-api.jp.nr-data.net/log/v1` for JP region |
 | Log Custom Attributes  | no | `none` | Attributes to be added to all logs forwarded to New Relic. Semicolon delimited (e.g. `env:prod;team:myTeam`) |
 | Max Retries To Resend Logs  | no | `3` | Number of times the function will attempt to resend data if there's a failure. |
 | Retry Interval  | no | `2000` | Interval between retry attempts in milliseconds. |
@@ -226,7 +226,7 @@ Azure Functions v4 uses a package deployment model. Code cannot be edited direct
 
 | Name | Default Value | Description |
 |------|---------------|-------------|
-| `NR_ENDPOINT` | `https://log-api.newrelic.com/log/v1` | New Relic Logs API endpoint. Use `https://log-api.newrelic.com/log/v1` for US, `https://log-api.eu.newrelic.com/log/v1` for EU, or `https://log-api.jp.newrelic.com/log/v1` for JP region |
+| `NR_ENDPOINT` | `https://log-api.newrelic.com/log/v1` | New Relic Logs API endpoint. Use `https://log-api.newrelic.com/log/v1` for US, `https://log-api.eu.newrelic.com/log/v1` for EU, or `https://log-api.jp.nr-data.net/log/v1` for JP region |
 | `NR_TAGS` | _(empty)_ | Custom attributes to add to all forwarded logs. Semicolon-delimited format: `env:prod;team:platform;app:myapp` |
 | `NR_MAX_RETRIES` | `3` | Number of retry attempts if sending logs to New Relic fails. |
 | `NR_RETRY_INTERVAL` | `2000` | Milliseconds to wait between retry attempts. |

--- a/armTemplates/azuredeploy-blobforwarder.json
+++ b/armTemplates/azuredeploy-blobforwarder.json
@@ -35,7 +35,7 @@
       "type": "string",
       "defaultValue": "https://log-api.newrelic.com/log/v1",
       "metadata": {
-        "description": "The Logs API endpoint used to send your logs to. By default, it is https://log-api.newrelic.com/log/v1 if your account is in the United States (US) region. Otherwise, if you're in the European Union (EU) region, you should use https://log-api.eu.newrelic.com/log/v1, or if you're in the Japan (JP) region, you should use https://log-api.jp.newrelic.com/log/v1"
+        "description": "The Logs API endpoint used to send your logs to. By default, it is https://log-api.newrelic.com/log/v1 if your account is in the United States (US) region. Otherwise, if you're in the European Union (EU) region, you should use https://log-api.eu.newrelic.com/log/v1, or if you're in the Japan (JP) region, you should use https://log-api.jp.nr-data.net/log/v1"
       }
     },
     "maxRetriesToResendLogs": {

--- a/armTemplates/azuredeploy-eventhubforwarder.json
+++ b/armTemplates/azuredeploy-eventhubforwarder.json
@@ -44,7 +44,7 @@
             "type": "string",
             "defaultValue": "https://log-api.newrelic.com/log/v1",
             "metadata": {
-                "description": "Optional. The Logs API endpoint used to send your logs to. By default, it is https://log-api.newrelic.com/log/v1 if your account is in the United States (US) region. Otherwise, if you're in the European Union (EU) region, you should use https://log-api.eu.newrelic.com/log/v1, or if you're in the Japan (JP) region, you should use https://log-api.jp.newrelic.com/log/v1"
+                "description": "Optional. The Logs API endpoint used to send your logs to. By default, it is https://log-api.newrelic.com/log/v1 if your account is in the United States (US) region. Otherwise, if you're in the European Union (EU) region, you should use https://log-api.eu.newrelic.com/log/v1, or if you're in the Japan (JP) region, you should use https://log-api.jp.nr-data.net/log/v1"
             }
         },
         "logCustomAttributes": {

--- a/bicep/azuredeploy-eventhubforwarder.bicep
+++ b/bicep/azuredeploy-eventhubforwarder.bicep
@@ -10,7 +10,7 @@ param eventHubName string = ''
 @description('Optional. Region where all resources included in this template will be deployed. Leave this blank to use the same region as the one of the resource group.')
 param location string = ''
 
-@description('Optional. The Logs API endpoint used to send your logs to. By default, it is https://log-api.newrelic.com/log/v1 if your account is in the United States (US) region. Otherwise, if you\'re in the European Union (EU) region, you should use https://log-api.eu.newrelic.com/log/v1, or if you\'re in the Japan (JP) region, you should use https://log-api.jp.newrelic.com/log/v1')
+@description('Optional. The Logs API endpoint used to send your logs to. By default, it is https://log-api.newrelic.com/log/v1 if your account is in the United States (US) region. Otherwise, if you\'re in the European Union (EU) region, you should use https://log-api.eu.newrelic.com/log/v1, or if you\'re in the Japan (JP) region, you should use https://log-api.jp.nr-data.net/log/v1')
 param newRelicEndpoint string = 'https://log-api.newrelic.com/log/v1'
 
 @description('Optional. List of semicolon-separated custom attributes that you would like to enrich the forwarded logs with. This can be useful, for example, if you want to indicate common attributes shared by all the logs collected in this account, such as: \'environment:production;department:sales;country:Germany\'')


### PR DESCRIPTION
## Summary
Updated the Japan (JP) region log API endpoint from `https://log-api.jp.newrelic.com/log/v1` to `https://log-api.jp.nr-data.net/log/v1` across all documentation and deployment templates.

## Changes
- Updated BlobForwarder README (2 occurrences)
- Updated EventHubForwarder README (2 occurrences)
- Updated ARM template for blob forwarder (1 occurrence)
- Updated ARM template for event hub forwarder (1 occurrence)
- Updated Bicep template for event hub forwarder (1 occurrence)

## Impact
This change ensures that customers using the JP region will be directed to use the correct endpoint for log ingestion.