### PR TITLE
feat: enforce TLS 1.2 on event hub forwarder and update api versions

### DIFF
--- a/armTemplates/azuredeploy-eventhubforwarder.json
+++ b/armTemplates/azuredeploy-eventhubforwarder.json
@@ -383,7 +383,7 @@
         },
         {
             "type": "Microsoft.EventHub/namespaces/AuthorizationRules",
-            "apiVersion": "2017-04-01",
+            "apiVersion": "2024-01-01",
             "name": "[concat(variables('eventHubNamespaceName'), '/', variables('logConsumerAuthorizationRuleName'))]",
             "location": "[variables('location')]",
             "dependsOn": [
@@ -397,7 +397,7 @@
         },
         {
             "type": "Microsoft.EventHub/namespaces/AuthorizationRules",
-            "apiVersion": "2017-04-01",
+            "apiVersion": "2024-01-01",
             "name": "[concat(variables('eventHubNamespaceName'), '/', variables('logProducerAuthorizationRuleName'))]",
             "condition": "[variables('createActivityLogsDiagnosticSetting')]",
             "location": "[variables('location')]",
@@ -736,7 +736,7 @@
         },
         {
             "type": "Microsoft.Storage/storageAccounts",
-            "apiVersion": "2021-04-01",
+            "apiVersion": "2024-01-01",
             "name": "[variables('storageAccountName')]",
             "location": "[variables('location')]",
             "sku": {
@@ -744,6 +744,7 @@
             },
             "kind": "StorageV2",
             "properties": {
+                "minimumTlsVersion": "TLS1_2",
                 "publicNetworkAccess": "[if(parameters('disablePublicAccessToStorageAccount'), 'Disabled', 'Enabled')]",
                 "allowBlobPublicAccess": false,
                 "networkAcls": "[if(parameters('disablePublicAccessToStorageAccount'), json('{\"bypass\": \"None\", \"defaultAction\": \"Deny\"}'), json('null'))]"
@@ -751,7 +752,7 @@
         },
         {
             "type": "Microsoft.Web/serverfarms",
-            "apiVersion": "2022-09-01",
+            "apiVersion": "2024-11-01",
             "name": "[variables('servicePlanName')]",
             "kind": "[variables('aspConfig').kind]",
             "location": "[variables('location')]",
@@ -760,7 +761,7 @@
         },
         {
             "type": "Microsoft.Web/sites",
-            "apiVersion": "2020-12-01",
+            "apiVersion": "2024-11-01",
             "name": "[variables('functionAppName')]",
             "location": "[variables('location')]",
             "kind": "functionapp",
@@ -780,9 +781,11 @@
             "properties": {
                 "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "siteConfig": {
-                    "appSettings": "[concat(variables('baseAppSettings'), if(variables('useManagedIdentity'), variables('managedIdentityAppSettings'), createArray(createObject('name', 'EVENTHUB_CONSUMER_CONNECTION', 'value', listKeys(variables('logConsumerAuthorizationRuleResourceId'), '2017-04-01').primaryConnectionString))), createArray(createObject('name', 'AzureWebJobsStorage', 'value', format(variables('azureWebJobsStorageConnectionFormat'), listKeys(variables('storageAccountResourceId'), '2021-04-01').keys[0].value))))]",
+                    "appSettings": "[concat(variables('baseAppSettings'), if(variables('useManagedIdentity'), variables('managedIdentityAppSettings'), createArray(createObject('name', 'EVENTHUB_CONSUMER_CONNECTION', 'value', listKeys(variables('logConsumerAuthorizationRuleResourceId'), '2024-01-01').primaryConnectionString))), createArray(createObject('name', 'AzureWebJobsStorage', 'value', format(variables('azureWebJobsStorageConnectionFormat'), listKeys(variables('storageAccountResourceId'), '2024-01-01').keys[0].value))))]",
                     "alwaysOn": "[parameters('disablePublicAccessToStorageAccount')]",
                     "ftpsState": "Disabled",
+                    "minTlsVersion": "1.2",
+                    "scmMinTlsVersion": "1.2",
                     "publicNetworkAccess": "[if(parameters('disablePublicAccessToStorageAccount'), 'Disabled', 'Enabled')]"
                 },
                 "httpsOnly": true
@@ -799,7 +802,7 @@
             ],
             "properties": {
                 "roleDefinitionId": "[variables('eventHubsDataReceiverRoleDefinitionId')]",
-                "principalId": "[if(variables('useManagedIdentity'), reference(resourceId('Microsoft.Web/sites', variables('functionAppName')), '2020-12-01', 'full').identity.principalId, '')]",
+                "principalId": "[if(variables('useManagedIdentity'), reference(resourceId('Microsoft.Web/sites', variables('functionAppName')), '2024-11-01', 'full').identity.principalId, '')]",
                 "principalType": "ServicePrincipal"
             }
         },
@@ -898,7 +901,7 @@
     "outputs": {
         "connectionString": {
             "type": "String",
-            "value": "[if(variables('useManagedIdentity'), '', listKeys(variables('logConsumerAuthorizationRuleResourceId'), '2017-04-01').primaryConnectionString)]"
+            "value": "[if(variables('useManagedIdentity'), '', listKeys(variables('logConsumerAuthorizationRuleResourceId'), '2024-01-01').primaryConnectionString)]"
         },
         "eventHubName": {
             "type": "string",

--- a/bicep/azuredeploy-eventhubforwarder.bicep
+++ b/bicep/azuredeploy-eventhubforwarder.bicep
@@ -213,7 +213,7 @@ resource eventHubNamespaceName_eventHubName_eventHubConsumerGroup 'Microsoft.Eve
   properties: {}
 }
 
-resource eventHubNamespaceName_logConsumerAuthorizationRule 'Microsoft.EventHub/namespaces/AuthorizationRules@2017-04-01' = {
+resource eventHubNamespaceName_logConsumerAuthorizationRule 'Microsoft.EventHub/namespaces/AuthorizationRules@2024-01-01' = {
   parent: eventHubNamespace_resource
   name: '${logConsumerAuthorizationRuleName}'
   location: location_var
@@ -228,7 +228,7 @@ resource eventHubNamespaceRef 'Microsoft.EventHub/namespaces@2024-01-01' existin
   name: eventHubNamespaceName
 }
 
-resource eventHubNamespaceName_logProducerAuthorizationRule 'Microsoft.EventHub/namespaces/AuthorizationRules@2017-04-01' = if (createActivityLogsDiagnosticSetting) {
+resource eventHubNamespaceName_logProducerAuthorizationRule 'Microsoft.EventHub/namespaces/AuthorizationRules@2024-01-01' = if (createActivityLogsDiagnosticSetting) {
   parent: eventHubNamespace_resource
   name: '${logProducerAuthorizationRuleName}'
   location: location_var
@@ -520,7 +520,7 @@ resource privateEndpointPrivateDnsZoneGroupsStorageQueue 'Microsoft.Network/priv
   ]
 }
 
-resource storageAccount 'Microsoft.Storage/storageAccounts@2021-04-01' = {
+resource storageAccount 'Microsoft.Storage/storageAccounts@2024-01-01' = {
   name: storageAccountName
   location: location_var
   sku: {
@@ -528,6 +528,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2021-04-01' = {
   }
   kind: 'StorageV2'
   properties: {
+    minimumTlsVersion: 'TLS1_2'
     publicNetworkAccess: (disablePublicAccessToStorageAccount ? 'Disabled' : 'Enabled')
     allowBlobPublicAccess: false
     networkAcls: (disablePublicAccessToStorageAccount
@@ -536,7 +537,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2021-04-01' = {
   }
 }
 
-resource servicePlan 'Microsoft.Web/serverfarms@2022-09-01' = {
+resource servicePlan 'Microsoft.Web/serverfarms@2024-11-01' = {
   name: servicePlanName
   kind: aspConfig.kind
   location: location_var
@@ -544,7 +545,7 @@ resource servicePlan 'Microsoft.Web/serverfarms@2022-09-01' = {
   properties: aspConfig.properties
 }
 
-resource functionApp 'Microsoft.Web/sites@2020-12-01' = {
+resource functionApp 'Microsoft.Web/sites@2024-11-01' = {
   name: functionAppName
   location: location_var
   kind: 'functionapp'
@@ -596,7 +597,7 @@ resource functionApp 'Microsoft.Web/sites@2020-12-01' = {
           }
           {
             name: 'AzureWebJobsStorage'
-            value: 'DefaultEndpointsProtocol=https;AccountName=${storageAccountName};AccountKey=${listkeys(storageAccount.id, '2021-04-01').keys[0].value};EndpointSuffix=${environment().suffixes.storage}'
+            value: 'DefaultEndpointsProtocol=https;AccountName=${storageAccountName};AccountKey=${listkeys(storageAccount.id, '2024-01-01').keys[0].value};EndpointSuffix=${environment().suffixes.storage}'
           }
           {
             name: 'EVENTHUB_FORWARDER_ENABLED'
@@ -624,12 +625,14 @@ resource functionApp 'Microsoft.Web/sites@2020-12-01' = {
           : [
               {
                 name: 'EVENTHUB_CONSUMER_CONNECTION'
-                value: listKeys(eventHubNamespaceName_logConsumerAuthorizationRule.id, '2017-04-01').primaryConnectionString
+                value: listKeys(eventHubNamespaceName_logConsumerAuthorizationRule.id, '2024-01-01').primaryConnectionString
               }
             ]
       )
       alwaysOn: disablePublicAccessToStorageAccount
       ftpsState: 'Disabled'
+      minTlsVersion: '1.2'
+      scmMinTlsVersion: '1.2'
       publicNetworkAccess: (disablePublicAccessToStorageAccount ? 'Disabled' : 'Enabled')
     }
     httpsOnly: true
@@ -699,5 +702,5 @@ module activityLogsDiagnosticSettingsAtSubscriptionLevelDeployment './activityLo
   ]
 }
 
-output connectionString string = useManagedIdentity ? '' : listKeys(eventHubNamespaceName_logConsumerAuthorizationRule.id, '2017-04-01').primaryConnectionString
+output connectionString string = useManagedIdentity ? '' : listKeys(eventHubNamespaceName_logConsumerAuthorizationRule.id, '2024-01-01').primaryConnectionString
 output eventHubName string = eventHubName_var


### PR DESCRIPTION
## Summary

- Add explicit TLS 1.2 minimums so deploys succeed in tenants that reject storage accounts without `minimumTlsVersion` set, and so the Function App stops relying on Azure's default TLS floor:
  - `Microsoft.Storage/storageAccounts` → `minimumTlsVersion: TLS1_2`
  - `Microsoft.Web/sites` `siteConfig` → `minTlsVersion: 1.2`, `scmMinTlsVersion: 1.2`
- Bump stale apiVersions so those properties (and the existing `publicNetworkAccess`) are actually honored by the RP instead of silently dropped:
  - `Microsoft.Storage/storageAccounts` 2021-04-01 → 2024-01-01
  - `Microsoft.Web/serverfarms` 2022-09-01 → 2024-11-01
  - `Microsoft.Web/sites` 2020-12-01 → 2024-11-01
  - `Microsoft.EventHub/namespaces/AuthorizationRules` 2017-04-01 → 2024-01-01
- Mirrored in both the ARM template and the bicep source; inline `listKeys()` / `reference()` apiVersion literals updated to match.
- Blob forwarder template intentionally left alone; will follow in a separate PR.

The storage apiVersion bump also fixes [NR-583707](https://new-relic.atlassian.net/browse/NR-583707) as a side effect: `disablePublicAccessToStorageAccount=true` previously left the portal's "Public network access" toggle at Enabled because the property was silently dropped on `2021-04-01`.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — unit tests pass (`__tests__/logForwarder.unit.test.js`, 50/50). Integration suites under `test-suite/` require live NR credentials and are not runnable locally.
- [x] Deployed the updated Event Hub forwarder to scratch RGs (ARM + Bicep × public + private, `centralus`, `logging-sandbox`). All four deploys succeeded and verified:
  - `az storage account show --query "{tls: minimumTlsVersion, pna: publicNetworkAccess}"` → `{ "tls": "TLS1_2", "pna": "Enabled" | "Disabled" }` per mode (non-null `pna` is the [NR-583707](https://new-relic.atlassian.net/browse/NR-583707) proof)
  - `az webapp show --query "siteConfig.{min: minTlsVersion, scm: scmMinTlsVersion}"` → `1.2` / `1.2`
  - `az eventhubs namespace show --query minimumTlsVersion` → `1.2` (regression)
- [x] With `disablePublicAccessToStorageAccount=true`, `az storage account show --query publicNetworkAccess` returns `Disabled` on both ARM and Bicep deploys — [NR-583707](https://new-relic.atlassian.net/browse/NR-583707) resolved.

Fixes [NR-580639](https://new-relic.atlassian.net/browse/NR-580639)
Fixes [NR-583707](https://new-relic.atlassian.net/browse/NR-583707)

[NR-583707]: https://new-relic.atlassian.net/browse/NR-583707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ