### PR TITLE
NR-587389: Add Trivy security scan and Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "11:00"
+      timezone: "Asia/Kolkata"
+    commit-message:
+      prefix: "build"
+      include: "scope"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "11:00"
+      timezone: "Asia/Kolkata"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "javascript"
+    commit-message:
+      prefix: "build"
+      include: "scope"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
       day: "monday"
       time: "11:00"
       timezone: "Asia/Kolkata"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "github-actions"
     commit-message:
       prefix: "build"
       include: "scope"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,14 +2,17 @@ name: New Relic Azure Functions - Pull Request
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Use Node.js 22.x
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: 22.x
     - name: Install Dependencies
@@ -20,9 +23,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Use Node.js 22.x
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: 22.x
     - name: Install Dependencies

--- a/.github/workflows/security_scan_pr_schedule.yaml
+++ b/.github/workflows/security_scan_pr_schedule.yaml
@@ -1,0 +1,75 @@
+name: Security Scan
+
+on:
+  pull_request:
+    branches: [master, main]
+  pull_request_target:
+    types: [opened, reopened]
+  schedule:
+    # Every day at 11:30 AM IST (6:00 AM UTC)
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  trivy:
+    name: Trivy security scan
+    if: github.event_name != 'pull_request_target'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        with:
+          scan-type: fs
+          ignore-unfixed: true
+          severity: 'HIGH,CRITICAL'
+          format: 'template'
+          template: '@/contrib/sarif.tpl'
+          output: 'trivy-results.sarif'
+          exit-code: '1'
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@b22c66273205240d86582638b860f9b25772b4d3 # v3
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'
+
+      - name: Notify Slack on scheduled scan failure
+        if: failure() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+        uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        with:
+          payload: |
+            {
+              "text": ":rotating_light: Trivy detected HIGH/CRITICAL CVEs on master in ${{ github.repository }}\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\nFindings: ${{ github.server_url }}/${{ github.repository }}/security/code-scanning?query=is%3Aopen+tool%3ATrivy"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TRIVY_WEBHOOK_URL }}
+
+  dependabot-notify:
+    name: Notify Slack on Dependabot PR
+    # IMPORTANT: This job uses pull_request_target which has full secrets access.
+    # Do NOT add a `checkout` step here — that would run PR-supplied code with secrets.
+    # This job's only purpose is to POST to Slack with metadata; nothing else.
+    if: github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack
+        uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        with:
+          payload: |
+            {
+              "text": ":robot_face: Dependabot opened a PR in ${{ github.repository }}\nTitle: ${{ github.event.pull_request.title }}\nPR: ${{ github.event.pull_request.html_url }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TRIVY_WEBHOOK_URL }}


### PR DESCRIPTION
## Summary

Sets up standard Logging Integrations security scanning on this repo, mirroring [newrelic/aws-log-ingestion#148](https://github.com/newrelic/aws-log-ingestion/pull/148). Ticket: [NR-587389](https://new-relic.atlassian.net/browse/NR-587389).

- Adds **Trivy** filesystem scan — gates PRs on HIGH/CRITICAL CVEs, runs daily at 11:30 AM IST on `master`, uploads SARIF to *Security → Code scanning*.
- Adds **Dependabot** config for weekly `github-actions` + `npm` updates.
- Adds **Slack notifications** — scheduled Trivy failures and new Dependabot PRs both post to [#logging-integrations-notifications](https://newrelic.enterprise.slack.com/archives/C0BF1LLLU3W) via `SLACK_TRIVY_WEBHOOK_URL`.
- Hardens `pr.yml`: adds least-privilege `permissions: contents: read`; SHA-pins `actions/checkout` (v2 → v4) and `actions/setup-node` (v1 → v4).
- **Omits the `trivy-image` job** — this repo has no `Dockerfile`, so there's nothing to build/scan. Per the [guide's adaptation table](https://newrelic.atlassian.net/wiki/spaces/TDP/pages/5816090942).

## Files changed

| File | Change |
| --- | --- |
| `.github/dependabot.yml` | **New** — weekly Mon 11:00 IST updates for `github-actions` + `npm` |
| `.github/workflows/security_scan_pr_schedule.yaml` | **New** — Trivy fs scan + Dependabot Slack notify |
| `.github/workflows/pr.yml` | **Updated** — permissions, SHA-pinned actions |

## Prerequisite

- [x] `SLACK_TRIVY_WEBHOOK_URL` repo secret must be configured (webhook value in vault, shared from `aws-log-ingestion` setup). If missing, PRs still merge and Trivy still gates — only the Slack pings are skipped.

## Test plan

- [x] CI runs Trivy `fs` scan on this PR and passes (or reports fixable HIGH/CRITICAL findings we can address).
- [x] SARIF results visible under *Security → Code scanning* after this PR runs.
- [ ] After merge: verify daily scheduled run appears under *Actions* (11:30 AM IST).
- [ ] After merge: verify Dependabot opens weekly PRs for `github-actions` and `npm`, and each PR posts to Slack.
- [x] Existing `lint` and `unit-test` jobs still pass with the SHA-pinned action versions.

[NR-587389]: https://new-relic.atlassian.net/browse/NR-587389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ