### PR TITLE
feat: add Flex Consumption + four-plan selection to the Event Hub forwarder…

### DIFF
--- a/NR-585965-flex-consumption-review.md
+++ b/NR-585965-flex-consumption-review.md
@@ -1,0 +1,141 @@
+# NR-585965 — Add Flex Consumption to the Event Hub forwarder (ARM)
+
+Reviewer guide for the changes to `armTemplates/azuredeploy-eventhubforwarder.json`.
+
+## Summary
+
+The Event Hub forwarder template today supports three hosting plans (ElasticPremium / Basic / Consumption), but the customer never picks one — it's *inferred* from `scalingMode` + `disablePublicAccessToStorageAccount`, and there's no Flex Consumption option.
+
+This change:
+- Adds a `functionAppPlan` parameter so the plan is a **direct choice** of four values.
+- Adds **FlexConsumption (FC1)** as the fourth plan and the new **default**.
+- Replaces the plan-guessing logic with a single `planConfig` lookup table (one row per plan), matching the pattern shipped for the VNet Flow Logs forwarder.
+- Adds the supporting resources Flex needs (code-delivery container + script, storage RBAC, private-networking wiring).
+
+Application code (`LogForwarder/index.js`) is **not touched** — this is deploy-time only.
+
+### References
+- Ticket: NR-585965 (parent NR-581117, Azure Logs Integration NorthStar)
+- Pattern source: `newrelic/azure-vnet-flow-logs` PR #26 (merged) + its DACI ("Multiple app service plans support in VNet Flow logs")
+- Approach confirmed with Pavan: mirror the four-plan pattern, Flex as default.
+
+## The design
+
+`scalingMode` used to do two jobs: pick the plan **and** inflate the Event Hub. This change removes only the first job — plan selection moves to `functionAppPlan`. `scalingMode` still controls Event Hub inflation (auto-inflate / throughput units / partitions) and per-plan scale (instance/worker counts), unchanged.
+
+**Before** (variables):
+```
+isHighScalabing / basicScaleConfig / aspConfig   → picked one of 3 ASP variables
+```
+**After**:
+```
+planConfig { FlexConsumption, ElasticPremium, Basic, Consumption }   ← 4-row table
+pc = planConfig[functionAppPlan]                                     ← the chosen row
+```
+Every resource reads `pc.<field>` and stays plan-agnostic. The three existing plans' specs are reproduced verbatim in their rows (backward compatible); only FlexConsumption is new.
+
+## Parameter & variable changes
+
+- **Added parameter** `functionAppPlan` — `[FlexConsumption (default), ElasticPremium, Basic, Consumption]`.
+- **Added variables**: `planConfig`, `pc`, `runFromPackageSetting`; role IDs (`storageBlobDataOwnerRoleId`, `storageQueueDataContributorRoleId`, `storageTableDataContributorRoleId`, `websiteContributorRoleId`, `storageFileDataPrivilegedContributorRoleId`); names (`deploymentIdentityName`, `deploymentScriptName`, `deploymentScriptsSubnetName`/`Id`, `sitesPrivateDnsZoneName`/`LinkName`, `functionAppPrivateEndpointName`/`DnsZoneGroupName`).
+- **Removed variable**: `functionNetworkConfigName` (dead after removing `networkConfig`).
+- **Trimmed `baseAppSettings`**: removed `FUNCTIONS_WORKER_RUNTIME`, `WEBSITE_NODE_DEFAULT_VERSION`, `WEBSITE_RUN_FROM_PACKAGE` — now applied per-plan (Flex sets runtime via `functionAppConfig`; the other three get worker-runtime settings; WRFP is conditional).
+
+## Resources — added / modified / removed
+
+### Added
+| Resource | Condition | Purpose |
+|---|---|---|
+| Validator `deploymentScripts` | Consumption + private | Fails fast with a clear message on the unsupported combo; function app depends on it. |
+| `blobServices` + `deployments` container | always | Where Flex stores/reads its code. |
+| 3× `roleAssignments` (Blob Owner, Queue + Table Contributor) | always | Function app identity → its own storage (needed for identity host storage + Flex code fetch). |
+| `userAssignedIdentities` (deployment identity) | Flex | Identity the code-push script runs as. |
+| `roleAssignments` (Website Contributor) | Flex | Lets that identity push code to the app. |
+| Flex `deploymentScripts` | Flex | Runs `az functionapp deployment source config-zip` to push `LogForwarder.zip`. |
+| `deployment-scripts-subnet` | (subnet, used when private) | Runs the deploy script inside the VNet in private mode. |
+| `roleAssignments` (Storage File Data Privileged Contributor) | Flex + private | Deploy script mounts the storage file share. |
+| Function-app private endpoint + `privatelink.azurewebsites.net` DNS zone + VNet link + zone group | Flex + private | Inbound path so the deploy script can reach the app when its public access is off. |
+
+### Modified
+| Resource | Change |
+|---|---|
+| `serverfarms` (service plan) | Reads `pc.kind/sku/properties` instead of `aspConfig`. |
+| `sites` (function app) | Plan-aware `kind` (Linux for Flex, Windows otherwise), always system-assigned identity, `reserved`, `functionAppConfig` (Flex only), `union()`-composed `siteConfig` with per-plan app settings, inline `virtualNetworkSubnetId`, `vnetRouteAllEnabled` (Flex+private only), plan-safe `alwaysOn`. |
+| `sites/extensions` (ZipDeploy) | Condition now `public && pc.usesRunFromPackage` — excludes Flex. |
+| VNet subnet | `delegations` now plan-aware (`Microsoft.App/environments` for Flex, `Microsoft.Web/serverFarms` for EP/Basic, none for Consumption). |
+
+### Removed
+| Resource | Why |
+|---|---|
+| `sites/networkConfig` | VNet integration moved to inline `virtualNetworkSubnetId` on the function app (matches the VNet forwarder's model). |
+
+## Plan behavior matrix
+
+| Plan | SKU / OS | Code delivery | VNet delegation |
+|---|---|---|---|
+| FlexConsumption (default) | FC1 / Linux | deploy script → `deployments` container | `Microsoft.App/environments` |
+| ElasticPremium | EP1 / Windows | ZipDeploy (public) / WRFP (private) | `Microsoft.Web/serverFarms` |
+| Basic | B1 / Windows | ZipDeploy (public) / WRFP (private) | `Microsoft.Web/serverFarms` |
+| Consumption | Y1 / Windows | ZipDeploy (public); private is blocked | none |
+
+## Comparison to the VNet forwarder (PR #26)
+
+Legend: ✅ same · 🔧 same idea, adapted to EH · ⚠️ intentionally different / EH-specific
+
+| Change | vs VNet | Notes |
+|---|---|---|
+| `functionAppPlan` param (4 values, Flex default) | ✅ | Identical |
+| `planConfig` + `pc` lookup | ✅ | Same structure; non-Flex rows reproduce EH's existing ASP specs |
+| `runFromPackageSetting` | ✅ | Identical |
+| Trim base app settings → per-plan | ✅ | Same approach |
+| Service plan reads `pc` | ✅ | Identical |
+| Function app: kind / identity / reserved / functionAppConfig / inline VNet / vnetRouteAll | ✅ | Same structure |
+| Host storage auth (identity in MI mode) | ✅ | Matches VNet + DACI |
+| 3 storage role grants (blob / queue / table) | ✅ | Identical |
+| Deployment identity + Website Contributor | ✅ | Identical |
+| Flex deploy script (`config-zip`) | ✅ | Identical |
+| ZipDeploy excludes Flex | ✅ | Identical |
+| Subnet delegation plan-aware | ✅ | Identical logic |
+| Validator (Consumption + private) | ✅ | Identical |
+| deployment-scripts subnet | ✅ | Same; EH uses `10.2.2.0/28` (its own address space) |
+| Storage File role on deploy identity | ✅ | Same; gated on Flex+private in EH (deploy identity is Flex-only) |
+| Script container / storage settings (private) | ✅ | Identical |
+| `deployments` container | 🔧 | VNet has a dedicated *function* storage account; EH has one storage account, so the container sits there |
+| Function app: app-setting **contents** | 🔧 | Structure identical; settings differ (`EVENTHUB_*` / `NR_*` vs flow-log settings — different apps) |
+| Function-app private endpoint + sites DNS | 🔧 | Same shape; EH gates on Flex+private and uses literal `privatelink.azurewebsites.net` (Flex isn't in Gov cloud) |
+| Function app: `alwaysOn` | ⚠️ | VNet sets it only on the Basic row (always true). EH keeps its **current** rule — `alwaysOn = private` for all non-Flex, Flex excluded — to avoid changing existing behavior. |
+| `networkConfig` removal | ⚠️ | EH-only change: VNet never had this resource. Removing it converges EH onto VNet's inline `virtualNetworkSubnetId` model. |
+| Source-storage Blob Data Reader role | ⚠️ omitted | VNet-only (reads flow-log *source* blobs). EH reads from the Event Hub, so not needed. |
+| Event Grid delivery-identity rework | ⚠️ omitted | VNet-specific. EH's activity-log Event Grid path is left untouched. |
+
+**Net:** the Flex machinery is a faithful port. The only deliberate divergences are `alwaysOn` (preserves EH's existing behavior) and the `networkConfig` removal (EH catching up to VNet's model); two VNet role/identity pieces are correctly omitted because EH doesn't need them.
+
+## Behavior changes reviewers should scrutinize
+
+1. **Default plan flips to FlexConsumption.** EH's previous default was Consumption (Y1). An existing customer who redeploys *without setting `functionAppPlan`* now gets Flex — a different tier family, which Azure cannot change in place. **This needs a product decision** (default Flex per the ticket, vs. default Consumption to protect existing installs). Currently set to Flex per the ticket.
+2. **Host storage auth in Managed-Identity mode** moved from a shared-key connection string to identity-based (`AzureWebJobsStorage__accountName`). Intended (matches VNet/DACI), but it's a change for existing MI deployments. Local Authentication mode still uses the shared-key string.
+3. **VNet integration mechanism** changed from a `networkConfig` resource to inline `virtualNetworkSubnetId`. Functionally equivalent; affects existing EP/Basic **private** deployments.
+4. **`WEBSITE_RUN_FROM_PACKAGE`** is no longer set to `'0'` on non-Flex public plans — those use the ZipDeploy extension, and WRFP is only set for non-Flex private.
+
+## Backward compatibility
+
+The ElasticPremium / Basic / Consumption rows reproduce today's ASP specs exactly, and `alwaysOn` keeps its current rule (`= private`) for those plans. So an existing customer who **explicitly** picks their current plan should see no resource drift — to be confirmed by a what-if run. The open risk is the *default* (point 1 above).
+
+## Known open items
+
+- **Default-plan decision** (point 1) — needs Pavan.
+- **Bicep mirror** — this change is ARM only; `bicep/azuredeploy-eventhubforwarder.bicep` still needs the same edits by hand.
+- **No sandbox test yet** — see test plan.
+
+## Test plan (required before merge)
+
+- `az deployment group what-if` against an existing Flex-equivalent and against each existing plan to check for unexpected drift.
+- Fresh deploy on each plan, public where valid:
+  - FlexConsumption + public — FC1, code lands via deploy script, forwards logs.
+  - ElasticPremium + public / + private.
+  - Basic + public / + private.
+  - Consumption + public.
+  - FlexConsumption + private — deploy script runs in-subnet, reaches app via private endpoint, forwards logs.
+  - Consumption + private — deployment must **fail** in ~1 min with the validator message.
+
+_ARM template validates as JSON. Not yet deployed to Azure._

--- a/armTemplates/azuredeploy-eventhubforwarder.json
+++ b/armTemplates/azuredeploy-eventhubforwarder.json
@@ -101,7 +101,20 @@
             ],
             "defaultValue": "Basic",
             "metadata": {
-                "description": "Optional. The scaling for the resources. If set to 'Enterprise', the Function app will be deployed in a Premium Function App Service Plan (with Scaling), otherwise it will be deployed in a Basic/Dynamic App Service Plan."
+                "description": "Optional. Controls Event Hub sizing and Function App scale-out. If set to 'Enterprise', the Event Hub namespace is auto-inflated (higher maximum throughput units and partition count) and the Function App is allowed more instances/workers; otherwise smaller defaults are used. This no longer selects the hosting plan - use the functionAppPlan parameter to choose the plan."
+            }
+        },
+        "functionAppPlan": {
+            "type": "string",
+            "defaultValue": "FlexConsumption",
+            "allowedValues": [
+                "FlexConsumption",
+                "ElasticPremium",
+                "Basic",
+                "Consumption"
+            ],
+            "metadata": {
+                "description": "Optional. Function App hosting plan. FlexConsumption (default) is the modern serverless plan, preferred where available. ElasticPremium is for production/bursty workloads or regions without Flex. Basic is a low-cost dedicated tier that still supports private networking. Consumption is pay-per-use for public dev/test only - deployment fails if combined with disablePublicAccessToStorageAccount=true. Note: Azure does not allow in-place plan changes across tier families; moving an existing deployment to a different plan requires a fresh deployment in a new resource group."
             }
         },
         "forwardAdministrativeAzureActivityLogs": {
@@ -211,61 +224,122 @@
         "privateEndpointPrivateDnsZoneGroupsStorageTableName": "[format('{0}/{1}', variables('privateEndpointStorageTableName'), 'tablePrivateDnsZoneGroup')]",
         "privateEndpointPrivateDnsZoneGroupsStorageQueueName": "[format('{0}/{1}', variables('privateEndpointStorageQueueName'), 'queuePrivateDnsZoneGroup')]",
 
-        "functionNetworkConfigName": "[format('{0}/{1}', variables('functionAppName'), 'virtualNetwork')]",
-        "autoscalingASP": {
-            "kind": "elastic",
-            "properties": {
-                "perSiteScaling": true,
-                "elasticScaleEnabled": true,
-                "maximumElasticWorkerCount": 20,
-                "zoneRedundant": false
+        "planConfig": {
+            "FlexConsumption": {
+                "kind": "functionapp,linux",
+                "properties": {
+                    "reserved": true
+                },
+                "sku": {
+                    "tier": "FlexConsumption",
+                    "name": "FC1"
+                },
+                "functionAppConfig": {
+                    "deployment": {
+                        "storage": {
+                            "type": "blobContainer",
+                            "value": "[concat('https://', variables('storageAccountName'), '.blob.', environment().suffixes.storage, '/deployments')]",
+                            "authentication": {
+                                "type": "SystemAssignedIdentity"
+                            }
+                        }
+                    },
+                    "scaleAndConcurrency": {
+                        "maximumInstanceCount": "[if(equals(parameters('scalingMode'), 'Enterprise'), 32, 4)]",
+                        "instanceMemoryMB": 2048
+                    },
+                    "runtime": {
+                        "name": "node",
+                        "version": "22"
+                    }
+                },
+                "subnetDelegation": "Microsoft.App/environments",
+                "usesRunFromPackage": false,
+                "usesIdentityStorage": true,
+                "functionAppReserved": true
             },
-            "sku": {
-                "name": "EP1",
-                "tier": "ElasticPremium",
-                "size": "EP1",
-                "family": "EP",
-                "capacity": 1
+            "ElasticPremium": {
+                "kind": "elastic",
+                "properties": {
+                    "perSiteScaling": true,
+                    "elasticScaleEnabled": true,
+                    "maximumElasticWorkerCount": 20,
+                    "zoneRedundant": false
+                },
+                "sku": {
+                    "name": "EP1",
+                    "tier": "ElasticPremium",
+                    "size": "EP1",
+                    "family": "EP",
+                    "capacity": 1
+                },
+                "functionAppConfig": null,
+                "subnetDelegation": "Microsoft.Web/serverFarms",
+                "usesRunFromPackage": true,
+                "usesIdentityStorage": false,
+                "functionAppReserved": false
+            },
+            "Basic": {
+                "kind": "app",
+                "properties": {
+                    "name": "[variables('servicePlanName')]",
+                    "targetWorkerCount": 1,
+                    "targetWorkerSizeId": 1,
+                    "workerSize": 1,
+                    "numberOfWorkers": 1,
+                    "computeMode": "Dynamic",
+                    "zoneRedundant": false
+                },
+                "sku": {
+                    "name": "B1",
+                    "tier": "Basic",
+                    "capacity": 1
+                },
+                "functionAppConfig": null,
+                "subnetDelegation": "Microsoft.Web/serverFarms",
+                "usesRunFromPackage": true,
+                "usesIdentityStorage": false,
+                "functionAppReserved": false
+            },
+            "Consumption": {
+                "kind": "functionapp",
+                "properties": {
+                    "name": "[variables('servicePlanName')]",
+                    "targetWorkerCount": 1,
+                    "targetWorkerSizeId": 1,
+                    "workerSize": "1",
+                    "numberOfWorkers": 1,
+                    "computeMode": "Dynamic"
+                },
+                "sku": {
+                    "name": "Y1",
+                    "tier": "Dynamic"
+                },
+                "functionAppConfig": null,
+                "subnetDelegation": "",
+                "usesRunFromPackage": true,
+                "usesIdentityStorage": false,
+                "functionAppReserved": false
             }
         },
-        "privateNetworkASP": {
-            "kind": "app",
-            "properties": {
-                "name": "[variables('servicePlanName')]",
-                "targetWorkerCount": 1,
-                "targetWorkerSizeId": 1,
-                "workerSize": 1,
-                "numberOfWorkers": 1,
-                "computeMode": "Dynamic",
-                "zoneRedundant": false
-            },
-            "sku": {
-                "name": "B1",
-                "tier": "Basic",
-                "capacity": 1
-            }
-        },
-        "defaultASP": {
-            "kind": "functionapp",
-            "properties": {
-                "name": "[variables('servicePlanName')]",
-                "targetWorkerCount": 1,
-                "targetWorkerSizeId": 1,
-                "workerSize": "1",
-                "numberOfWorkers": 1,
-                "computeMode": "Dynamic"
-            },
-            "sku": {
-                "name": "Y1",
-                "tier": "Dynamic"
-            }
-        },
-        "isHighScalabing": "[if(equals(parameters('scalingMode'), 'Enterprise'), true(), false())]",
-        "basicScaleConfig": "[if(and(equals(parameters('scalingMode'), 'Basic'), parameters('disablePublicAccessToStorageAccount')), variables('privateNetworkASP'), variables('defaultASP'))]",
-        "aspConfig": "[if(variables('isHighScalabing'), variables('autoscalingASP'), variables('basicScaleConfig'))]",
+        "pc": "[variables('planConfig')[parameters('functionAppPlan')]]",
+        "runFromPackageSetting": "[if(and(variables('pc').usesRunFromPackage, parameters('disablePublicAccessToStorageAccount')), createArray(createObject('name', 'WEBSITE_RUN_FROM_PACKAGE', 'value', variables('eventHubForwarderFunctionArtifact'))), createArray())]",
 
         "useManagedIdentity": "[equals(parameters('authenticationMode'), 'Managed Identity')]",
         "eventHubsDataReceiverRoleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a638d3c7-ab3a-418d-83e6-5f17a39d4fde')]",
+        "storageBlobDataOwnerRoleId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b7e6dc6d-f1e8-4753-8033-0f276bb0955b')]",
+        "storageQueueDataContributorRoleId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '974c5e8b-45b9-4653-ba55-5f855dd0fb88')]",
+        "storageTableDataContributorRoleId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3')]",
+        "websiteContributorRoleId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'de139f84-1756-47ae-9be6-808fbbe84772')]",
+        "deploymentIdentityName": "[concat('nrlogs-deploy-identity-', variables('onePerResourceGroupAndEventHubUniqueSuffix'))]",
+        "deploymentScriptName": "[concat('nrlogs-deploy-script-', variables('onePerResourceGroupAndEventHubUniqueSuffix'))]",
+        "storageFileDataPrivilegedContributorRoleId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '69566ab7-960f-475b-8e7c-b3118f30c6bd')]",
+        "deploymentScriptsSubnetName": "deployment-scripts-subnet",
+        "deploymentScriptsSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('deploymentScriptsSubnetName'))]",
+        "sitesPrivateDnsZoneName": "privatelink.azurewebsites.net",
+        "sitesPrivateDnsZoneVirtualNetworkLinkName": "[format('{0}/{1}-link', variables('sitesPrivateDnsZoneName'), variables('virtualNetworkName'))]",
+        "functionAppPrivateEndpointName": "[format('{0}-sites-private-endpoint', variables('functionAppName'))]",
+        "functionAppPrivateEndpointDnsZoneGroupName": "[format('{0}/{1}', variables('functionAppPrivateEndpointName'), 'sitesPrivateDnsZoneGroup')]",
         "logConsumerAuthorizationRuleResourceId": "[resourceId('Microsoft.EventHub/namespaces/AuthorizationRules', variables('eventHubNamespaceName'), variables('logConsumerAuthorizationRuleName'))]",
         "storageAccountResourceId": "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]",
         "azureWebJobsStorageConnectionFormat": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageAccountName'), ';AccountKey={0};EndpointSuffix=', environment().suffixes.storage)]",
@@ -316,20 +390,8 @@
                 "value": "~4"
             },
             {
-                "name": "FUNCTIONS_WORKER_RUNTIME",
-                "value": "node"
-            },
-            {
-                "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                "value": "~22"
-            },
-            {
                 "name": "EVENTHUB_FORWARDER_ENABLED",
                 "value": "true"
-            },
-            {
-                "name": "WEBSITE_RUN_FROM_PACKAGE",
-                "value": "[if(parameters('disablePublicAccessToStorageAccount'), variables('eventHubForwarderFunctionArtifact'),'0')]"
             }
         ],
         "managedIdentityAppSettings": [
@@ -341,6 +403,21 @@
 
     },
     "resources": [
+        {
+            "condition": "[and(equals(parameters('functionAppPlan'), 'Consumption'), parameters('disablePublicAccessToStorageAccount'))]",
+            "type": "Microsoft.Resources/deploymentScripts",
+            "apiVersion": "2023-08-01",
+            "name": "[concat('nrlogs-validate-plan-', variables('onePerResourceGroupAndEventHubUniqueSuffix'))]",
+            "location": "[variables('location')]",
+            "kind": "AzureCLI",
+            "properties": {
+                "azCliVersion": "2.61.0",
+                "timeout": "PT5M",
+                "retentionInterval": "PT1H",
+                "cleanupPreference": "OnSuccess",
+                "scriptContent": "echo 'ERROR: Consumption (Y1) plan does not support private networking. Choose ElasticPremium or Basic for a private deployment, or set disablePublicAccessToStorageAccount=false to keep Consumption on the public network.' >&2; exit 1"
+            }
+        },
         {
             "type": "Microsoft.EventHub/namespaces",
             "apiVersion": "2024-01-01",
@@ -428,14 +505,7 @@
                         "properties": {
                             "privateEndpointNetworkPolicies": "Enabled",
                             "privateLinkServiceNetworkPolicies": "Enabled",
-                            "delegations": [
-                            {
-                                "name": "webapp",
-                                "properties": {
-                                "serviceName": "Microsoft.Web/serverFarms"
-                                }
-                            }
-                            ],
+                            "delegations": "[if(empty(variables('pc').subnetDelegation), createArray(), createArray(createObject('name', 'delegation', 'properties', createObject('serviceName', variables('pc').subnetDelegation))))]",
                             "addressPrefix": "10.2.0.0/24"
                         }
                     },
@@ -445,6 +515,20 @@
                             "privateEndpointNetworkPolicies": "Disabled",
                             "privateLinkServiceNetworkPolicies": "Enabled",
                             "addressPrefix": "10.2.1.0/24"
+                        }
+                    },
+                    {
+                        "name": "[variables('deploymentScriptsSubnetName')]",
+                        "properties": {
+                            "addressPrefix": "10.2.2.0/28",
+                            "delegations": [
+                                {
+                                    "name": "delegation",
+                                    "properties": {
+                                        "serviceName": "Microsoft.ContainerInstance/containerGroups"
+                                    }
+                                }
+                            ]
                         }
                     }
                 ]
@@ -747,27 +831,122 @@
                 "minimumTlsVersion": "TLS1_2",
                 "publicNetworkAccess": "[if(parameters('disablePublicAccessToStorageAccount'), 'Disabled', 'Enabled')]",
                 "allowBlobPublicAccess": false,
-                "networkAcls": "[if(parameters('disablePublicAccessToStorageAccount'), json('{\"bypass\": \"None\", \"defaultAction\": \"Deny\"}'), json('null'))]"
+                "networkAcls": "[if(parameters('disablePublicAccessToStorageAccount'), json('{\"bypass\": \"AzureServices\", \"defaultAction\": \"Deny\"}'), json('null'))]"
+            }
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts/blobServices",
+            "apiVersion": "2024-01-01",
+            "name": "[concat(variables('storageAccountName'), '/default')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
+            ],
+            "properties": {}
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+            "apiVersion": "2024-01-01",
+            "name": "[concat(variables('storageAccountName'), '/default/deployments')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts/blobServices', variables('storageAccountName'), 'default')]"
+            ],
+            "properties": {
+                "publicAccess": "None"
+            }
+        },
+        {
+            "condition": "[and(equals(parameters('functionAppPlan'), 'FlexConsumption'), parameters('disablePublicAccessToStorageAccount'))]",
+            "type": "Microsoft.Network/privateDnsZones",
+            "apiVersion": "2020-06-01",
+            "name": "[variables('sitesPrivateDnsZoneName')]",
+            "location": "global"
+        },
+        {
+            "condition": "[and(equals(parameters('functionAppPlan'), 'FlexConsumption'), parameters('disablePublicAccessToStorageAccount'))]",
+            "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
+            "apiVersion": "2020-06-01",
+            "name": "[variables('sitesPrivateDnsZoneVirtualNetworkLinkName')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/privateDnsZones', variables('sitesPrivateDnsZoneName'))]",
+                "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]"
+            ],
+            "location": "global",
+            "properties": {
+                "registrationEnabled": false,
+                "virtualNetwork": {
+                    "id": "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]"
+                }
+            }
+        },
+        {
+            "condition": "[and(equals(parameters('functionAppPlan'), 'FlexConsumption'), parameters('disablePublicAccessToStorageAccount'))]",
+            "type": "Microsoft.Network/privateEndpoints",
+            "apiVersion": "2022-05-01",
+            "name": "[variables('functionAppPrivateEndpointName')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', variables('functionAppName'))]",
+                "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]"
+            ],
+            "location": "[variables('location')]",
+            "properties": {
+                "subnet": {
+                    "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('privateEndpointsSubnetName'))]"
+                },
+                "privateLinkServiceConnections": [
+                    {
+                        "name": "MyFunctionAppSitesPrivateLinkConnection",
+                        "properties": {
+                            "privateLinkServiceId": "[resourceId('Microsoft.Web/sites', variables('functionAppName'))]",
+                            "groupIds": [
+                                "sites"
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "condition": "[and(equals(parameters('functionAppPlan'), 'FlexConsumption'), parameters('disablePublicAccessToStorageAccount'))]",
+            "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
+            "apiVersion": "2022-05-01",
+            "name": "[variables('functionAppPrivateEndpointDnsZoneGroupName')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/privateEndpoints', variables('functionAppPrivateEndpointName'))]",
+                "[resourceId('Microsoft.Network/privateDnsZones', variables('sitesPrivateDnsZoneName'))]"
+            ],
+            "properties": {
+                "privateDnsZoneConfigs": [
+                    {
+                        "name": "config",
+                        "properties": {
+                            "privateDnsZoneId": "[resourceId('Microsoft.Network/privateDnsZones', variables('sitesPrivateDnsZoneName'))]"
+                        }
+                    }
+                ]
             }
         },
         {
             "type": "Microsoft.Web/serverfarms",
             "apiVersion": "2024-11-01",
             "name": "[variables('servicePlanName')]",
-            "kind": "[variables('aspConfig').kind]",
+            "kind": "[variables('pc').kind]",
             "location": "[variables('location')]",
-            "sku": "[variables('aspConfig').sku]",
-            "properties": "[variables('aspConfig').properties]"
+            "sku": "[variables('pc').sku]",
+            "properties": "[variables('pc').properties]"
         },
         {
             "type": "Microsoft.Web/sites",
             "apiVersion": "2024-11-01",
             "name": "[variables('functionAppName')]",
             "location": "[variables('location')]",
-            "kind": "functionapp",
-            "identity": "[if(variables('useManagedIdentity'), json('{\"type\": \"SystemAssigned\"}'), json('null'))]",
+            "kind": "[if(variables('pc').functionAppReserved, 'functionapp,linux', 'functionapp')]",
+            "identity": {
+                "type": "SystemAssigned"
+            },
             "dependsOn": [
+                "[resourceId('Microsoft.Resources/deploymentScripts', concat('nrlogs-validate-plan-', variables('onePerResourceGroupAndEventHubUniqueSuffix')))]",
                 "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]",
+                "[resourceId('Microsoft.Storage/storageAccounts/blobServices/containers', variables('storageAccountName'), 'default', 'deployments')]",
                 "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
                 "[resourceId('Microsoft.Network/privateEndpoints/privateDnsZoneGroups', variables('privateEndpointStorageBlobName'), 'blobPrivateDnsZoneGroup')]",
                 "[resourceId('Microsoft.Network/privateEndpoints/privateDnsZoneGroups', variables('privateEndpointStorageFileName'), 'filePrivateDnsZoneGroup')]",
@@ -780,15 +959,12 @@
             ],
             "properties": {
                 "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('servicePlanName'))]",
-                "siteConfig": {
-                    "appSettings": "[concat(variables('baseAppSettings'), if(variables('useManagedIdentity'), variables('managedIdentityAppSettings'), createArray(createObject('name', 'EVENTHUB_CONSUMER_CONNECTION', 'value', listKeys(variables('logConsumerAuthorizationRuleResourceId'), '2024-01-01').primaryConnectionString))), createArray(createObject('name', 'AzureWebJobsStorage', 'value', format(variables('azureWebJobsStorageConnectionFormat'), listKeys(variables('storageAccountResourceId'), '2024-01-01').keys[0].value))))]",
-                    "alwaysOn": "[parameters('disablePublicAccessToStorageAccount')]",
-                    "ftpsState": "Disabled",
-                    "minTlsVersion": "1.2",
-                    "scmMinTlsVersion": "1.2",
-                    "publicNetworkAccess": "[if(parameters('disablePublicAccessToStorageAccount'), 'Disabled', 'Enabled')]"
-                },
-                "httpsOnly": true
+                "reserved": "[variables('pc').functionAppReserved]",
+                "httpsOnly": true,
+                "vnetRouteAllEnabled": "[and(equals(parameters('functionAppPlan'), 'FlexConsumption'), parameters('disablePublicAccessToStorageAccount'))]",
+                "virtualNetworkSubnetId": "[if(and(parameters('disablePublicAccessToStorageAccount'), not(empty(variables('pc').subnetDelegation))), resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('functionSubnetName')), null())]",
+                "functionAppConfig": "[variables('pc').functionAppConfig]",
+                "siteConfig": "[union(createObject('appSettings', concat(variables('baseAppSettings'), if(equals(parameters('functionAppPlan'), 'FlexConsumption'), createArray(), createArray(createObject('name', 'FUNCTIONS_WORKER_RUNTIME', 'value', 'node'), createObject('name', 'WEBSITE_NODE_DEFAULT_VERSION', 'value', '~22'))), if(or(variables('pc').usesIdentityStorage, variables('useManagedIdentity')), createArray(createObject('name', 'AzureWebJobsStorage__accountName', 'value', variables('storageAccountName'))), createArray(createObject('name', 'AzureWebJobsStorage', 'value', format(variables('azureWebJobsStorageConnectionFormat'), listKeys(variables('storageAccountResourceId'), '2024-01-01').keys[0].value)))), if(variables('useManagedIdentity'), variables('managedIdentityAppSettings'), createArray(createObject('name', 'EVENTHUB_CONSUMER_CONNECTION', 'value', listKeys(variables('logConsumerAuthorizationRuleResourceId'), '2024-01-01').primaryConnectionString))), variables('runFromPackageSetting')), 'ftpsState', 'Disabled', 'minTlsVersion', '1.2', 'scmMinTlsVersion', '1.2', 'publicNetworkAccess', if(parameters('disablePublicAccessToStorageAccount'), 'Disabled', 'Enabled')), if(equals(parameters('functionAppPlan'), 'FlexConsumption'), createObject(), createObject('alwaysOn', parameters('disablePublicAccessToStorageAccount'))))]"
             }
         },
         {
@@ -807,7 +983,124 @@
             }
         },
         {
-            "condition": "[not(parameters('disablePublicAccessToStorageAccount'))]",
+            "type": "Microsoft.Authorization/roleAssignments",
+            "apiVersion": "2022-04-01",
+            "name": "[guid(resourceId('Microsoft.Web/sites', variables('functionAppName')), variables('storageAccountResourceId'), 'StorageBlobDataOwner')]",
+            "scope": "[variables('storageAccountResourceId')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', variables('functionAppName'))]"
+            ],
+            "properties": {
+                "roleDefinitionId": "[variables('storageBlobDataOwnerRoleId')]",
+                "principalId": "[reference(resourceId('Microsoft.Web/sites', variables('functionAppName')), '2024-11-01', 'full').identity.principalId]",
+                "principalType": "ServicePrincipal"
+            }
+        },
+        {
+            "type": "Microsoft.Authorization/roleAssignments",
+            "apiVersion": "2022-04-01",
+            "name": "[guid(resourceId('Microsoft.Web/sites', variables('functionAppName')), variables('storageAccountResourceId'), 'StorageQueueDataContributor')]",
+            "scope": "[variables('storageAccountResourceId')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', variables('functionAppName'))]"
+            ],
+            "properties": {
+                "roleDefinitionId": "[variables('storageQueueDataContributorRoleId')]",
+                "principalId": "[reference(resourceId('Microsoft.Web/sites', variables('functionAppName')), '2024-11-01', 'full').identity.principalId]",
+                "principalType": "ServicePrincipal"
+            }
+        },
+        {
+            "type": "Microsoft.Authorization/roleAssignments",
+            "apiVersion": "2022-04-01",
+            "name": "[guid(resourceId('Microsoft.Web/sites', variables('functionAppName')), variables('storageAccountResourceId'), 'StorageTableDataContributor')]",
+            "scope": "[variables('storageAccountResourceId')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', variables('functionAppName'))]"
+            ],
+            "properties": {
+                "roleDefinitionId": "[variables('storageTableDataContributorRoleId')]",
+                "principalId": "[reference(resourceId('Microsoft.Web/sites', variables('functionAppName')), '2024-11-01', 'full').identity.principalId]",
+                "principalType": "ServicePrincipal"
+            }
+        },
+        {
+            "condition": "[equals(parameters('functionAppPlan'), 'FlexConsumption')]",
+            "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+            "apiVersion": "2023-01-31",
+            "name": "[variables('deploymentIdentityName')]",
+            "location": "[variables('location')]"
+        },
+        {
+            "condition": "[equals(parameters('functionAppPlan'), 'FlexConsumption')]",
+            "type": "Microsoft.Authorization/roleAssignments",
+            "apiVersion": "2022-04-01",
+            "name": "[guid(resourceId('Microsoft.Web/sites', variables('functionAppName')), variables('deploymentIdentityName'), 'WebsiteContributor')]",
+            "scope": "[resourceId('Microsoft.Web/sites', variables('functionAppName'))]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', variables('functionAppName'))]",
+                "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('deploymentIdentityName'))]"
+            ],
+            "properties": {
+                "roleDefinitionId": "[variables('websiteContributorRoleId')]",
+                "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('deploymentIdentityName')), '2023-01-31').principalId]",
+                "principalType": "ServicePrincipal"
+            }
+        },
+        {
+            "condition": "[and(equals(parameters('functionAppPlan'), 'FlexConsumption'), parameters('disablePublicAccessToStorageAccount'))]",
+            "type": "Microsoft.Authorization/roleAssignments",
+            "apiVersion": "2022-04-01",
+            "name": "[guid(variables('storageAccountResourceId'), variables('deploymentIdentityName'), 'StorageFileDataPrivilegedContributor')]",
+            "scope": "[variables('storageAccountResourceId')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]",
+                "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('deploymentIdentityName'))]"
+            ],
+            "properties": {
+                "roleDefinitionId": "[variables('storageFileDataPrivilegedContributorRoleId')]",
+                "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('deploymentIdentityName')), '2023-01-31').principalId]",
+                "principalType": "ServicePrincipal"
+            }
+        },
+        {
+            "condition": "[equals(parameters('functionAppPlan'), 'FlexConsumption')]",
+            "type": "Microsoft.Resources/deploymentScripts",
+            "apiVersion": "2023-08-01",
+            "name": "[variables('deploymentScriptName')]",
+            "location": "[variables('location')]",
+            "kind": "AzureCLI",
+            "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                    "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('deploymentIdentityName'))]": {}
+                }
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', variables('functionAppName'))]",
+                "[extensionResourceId(resourceId('Microsoft.Web/sites', variables('functionAppName')), 'Microsoft.Authorization/roleAssignments', guid(resourceId('Microsoft.Web/sites', variables('functionAppName')), variables('deploymentIdentityName'), 'WebsiteContributor'))]",
+                "[extensionResourceId(variables('storageAccountResourceId'), 'Microsoft.Authorization/roleAssignments', guid(variables('storageAccountResourceId'), variables('deploymentIdentityName'), 'StorageFileDataPrivilegedContributor'))]",
+                "[resourceId('Microsoft.Network/privateEndpoints/privateDnsZoneGroups', variables('privateEndpointStorageBlobName'), 'blobPrivateDnsZoneGroup')]",
+                "[resourceId('Microsoft.Network/privateEndpoints/privateDnsZoneGroups', variables('privateEndpointStorageFileName'), 'filePrivateDnsZoneGroup')]",
+                "[resourceId('Microsoft.Network/privateEndpoints/privateDnsZoneGroups', variables('functionAppPrivateEndpointName'), 'sitesPrivateDnsZoneGroup')]"
+            ],
+            "properties": {
+                "azCliVersion": "2.61.0",
+                "timeout": "PT15M",
+                "retentionInterval": "PT1H",
+                "cleanupPreference": "OnSuccess",
+                "containerSettings": "[if(parameters('disablePublicAccessToStorageAccount'), json(concat('{\"subnetIds\": [{\"id\": \"', variables('deploymentScriptsSubnetId'), '\"}]}')), json('null'))]",
+                "storageAccountSettings": "[if(parameters('disablePublicAccessToStorageAccount'), json(concat('{\"storageAccountName\": \"', variables('storageAccountName'), '\"}')), json('null'))]",
+                "environmentVariables": [
+                    { "name": "ZIP_URL", "value": "[variables('eventHubForwarderFunctionArtifact')]" },
+                    { "name": "FUNCTION_APP", "value": "[variables('functionAppName')]" },
+                    { "name": "RESOURCE_GROUP", "value": "[resourceGroup().name]" }
+                ],
+                "scriptContent": "set -euo pipefail\necho 'Downloading package...'\npython3 -c \"import os, urllib.request; urllib.request.urlretrieve(os.environ['ZIP_URL'], '/tmp/package.zip')\"\nls -la /tmp/package.zip\necho 'Deploying via az functionapp deployment source config-zip...'\naz functionapp deployment source config-zip --resource-group \"$RESOURCE_GROUP\" --name \"$FUNCTION_APP\" --src /tmp/package.zip --build-remote false --timeout 300\n"
+            }
+        },
+        {
+            "condition": "[and(not(parameters('disablePublicAccessToStorageAccount')), variables('pc').usesRunFromPackage)]",
             "type": "Microsoft.Web/sites/extensions",
             "name": "[concat(variables('functionAppName'), '/ZipDeploy')]",
             "dependsOn": [
@@ -816,20 +1109,6 @@
             "apiVersion": "2020-12-01",
             "properties": {
                 "packageUri": "[variables('eventHubForwarderFunctionArtifact')]"
-            }
-        },
-        {
-            "condition": "[parameters('disablePublicAccessToStorageAccount')]",
-            "type": "Microsoft.Web/sites/networkConfig",
-            "apiVersion": "2022-03-01",
-            "name": "[variables('functionNetworkConfigName')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Web/sites', variables('functionAppName'))]",
-                "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]"
-            ],
-            "properties": {
-                "subnetResourceId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('functionSubnetName'))]",
-                "swiftSupported": true
             }
         },
         {


### PR DESCRIPTION
## Summary

Adds a `functionAppPlan` parameter so the Event Hub forwarder's hosting plan is a direct, deploy-time choice, and adds **Flex Consumption (FC1)** as a fourth plan and the new default. Previously the plan was inferred from `scalingMode` + `disablePublicAccessToStorageAccount`, and Flex wasn't available at all.

Mirrors the four-plan pattern shipped for the VNet Flow Logs forwarder ([PR #26](https://github.com/newrelic/azure-vnet-flow-logs/pull/26)) and its [DACI](https://newrelic.atlassian.net/wiki/spaces/TDP/pages/5832638842). Forwarder app code is untouched — deploy-time only.

Ticket: NR-585965.

## What changed

- New `functionAppPlan` param — `FlexConsumption` (default) / `ElasticPremium` / `Basic` / `Consumption`.
- Replaced the three ASP variables + inference ternaries with a single `planConfig` lookup + `pc` alias; every resource reads `pc.<field>`.
- Flex-only infra: `deployments` blob container, user-assigned deployment identity, Flex `deploymentScripts` (`config-zip`), and — for Flex + private — a deployment-scripts subnet and a function-app private endpoint.
- Unconditional Storage Blob/Queue/Table Data role assignments on the function app's (now always-on) system-assigned identity, so identity-based host storage works on any plan.
- Removed `Microsoft.Web/sites/networkConfig`; VNet integration is now inline `virtualNetworkSubnetId`.
- Validator resource that fails Consumption + private at parameter time with a clear message.
- `scalingMode` now controls only Event Hub sizing (auto-inflate / throughput / partitions), not plan selection.
- Legacy plans (EP/Basic/Consumption) reproduce today's specs verbatim (Windows, `alwaysOn = private`).

## Plans

| Plan | SKU / OS | Code delivery | Private networking |
|---|---|---|---|
| FlexConsumption (default) | FC1 / Linux | deploy script → container | ✅ |
| ElasticPremium | EP1 / Windows | ZipDeploy / WRFP | ✅ |
| Basic | B1 / Windows | ZipDeploy / WRFP | ✅ |
| Consumption | Y1 / Windows | ZipDeploy | ❌ (fails fast) |

## Testing

Deployed to a sandbox subscription; **all 8 scenarios (4 plans × public/private) verified**:

| Plan | Public | Private |
|---|---|---|
| FlexConsumption | ✅ deploy + logs in NR (end-to-end) | ✅ deploy |
| ElasticPremium | ✅ deploy + e2e | ✅ deploy + e2e |
| Basic | ✅ deploy + e2e | ✅ deploy + e2e |
| Consumption | ✅ deploy + e2e | ✅ fails at validator (expected) |

End-to-end = a test event sent to the deployment's Event Hub appeared as a log in New Relic. Two bugs were found and fixed during testing (both private-path only): a role-assignment `dependsOn` needed `extensionResourceId`, and storage `networkAcls.bypass` needed `AzureServices` for the deployment script to reach firewalled storage.

Note: EP/Basic/Consumption require App Service compute quota, which is region-specific in the sandbox — tested in `westus2`. Flex is unaffected. Backward compat: redeploying an existing plan explicitly produces the same resources (legacy rows are byte-for-byte unchanged).

## Out of scope

- Bicep mirror (separate ticket).
- Migration of existing deployments from a legacy plan to Flex (separate follow-up — Azure can't change tier family in place).
- Application Insights wiring for the function app is absent (pre-existing; not added here) — a possible future observability improvement.
