### PR TITLE
fix: publish release artifacts to Azure Blob Storage via OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,9 @@ jobs:
   job-generate-release:
     runs-on: ubuntu-latest
     needs: [job-generate-third-party-notices]
+    permissions:
+      id-token: write # Required for password-less (OIDC) login to Azure
+      contents: read
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -115,6 +118,16 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      # Logs in to Azure using OIDC (no stored password). semantic-release (below) then
+      # uploads the release ZIP to blob storage via its publishCmd, using this session.
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_PUBLISHER_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_PUBLISHER_TENANT_ID }}
+          # logging-production subscription (not secret; also referenced in service-account-permissions)
+          subscription-id: 2bcc5e68-e25e-4c2a-9f73-f4e26bd6fc7a
 
       - name: Run semantic-release
         env:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -18,7 +18,8 @@
       "placeholder": "0.0.0-development"
     }],
     ["@semantic-release/exec", {
-      "prepareCmd": "npm run package:logforwarder"
+      "prepareCmd": "npm run package:logforwarder",
+      "publishCmd": "sha256sum LogForwarder.zip > LogForwarder.zip.sha256 && az storage blob upload --account-name nrloggingprodreleases --container-name releases --name log-forwarder-${nextRelease.version}.zip --file LogForwarder.zip --auth-mode login --overwrite && az storage blob upload --account-name nrloggingprodreleases --container-name releases --name log-forwarder-${nextRelease.version}.zip.sha256 --file LogForwarder.zip.sha256 --auth-mode login --overwrite"
     }],
     ["@semantic-release/github", {
       "assets": [


### PR DESCRIPTION
## What does this PR do? Why is it needed?

Adds a step to the release pipeline that publishes each release ZIP + SHA256 checksum to Azure Blob Storage, alongside the existing GitHub Release. Part of Phase 2 ("Shadow Publishing") of the Azure Function artifact publihing — no ARM template changes yet, so no customer-facing impact.

Background: customers hit intermittent SSL certificate-chain failures when Azure downloads deployment packages from GitHub Release URLs (flagged as risky by Microsoft). Long-term fix is hosting artifacts on Azure's own storage.

Auth uses a federated OIDC service principal (no stored secret), scoped only to the `nrloggingprodreleases` storage account.

## Special notes for your reviewer

- Requires `AZURE_PUBLISHER_CLIENT_ID`/`AZURE_PUBLISHER_TENANT_ID` repo secrets — already added.
- Naming (`log-forwarder-<version>.zip`) agreed with Josep on NR-530181.
- Tagged `fix:` not `feat:` — internal plumbing only, no customer-visible change yet.

## Details of Testing Done

- Verified in Azure: service principal, federated credential, and role assignment (scoped to just this storage account) all confirmed correct.
- `npx semantic-release --dry-run` locally — config loads cleanly.
- Manually resolved the publish command with a test version to confirm `az` CLI syntax is valid.
- No live upload tested locally (SP only authenticates via GitHub Actions OIDC) — first real run happens on next merge to master.

## Checklist

- [x] Unit tests updated — N/A (workflow config only)
- [x] Documentation updated in README.md — N/A (no user-facing change)
- [x] Manual testing details added