### PR TITLE
feat: point deployment package URL to Azure Blob Storage

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -13,7 +13,10 @@
     }],
     ["semantic-release-plugin-update-version-in-files", {
       "files": [
-        "LogForwarder/index.js"
+        "LogForwarder/index.js",
+        "armTemplates/azuredeploy-eventhubforwarder.json",
+        "armTemplates/azuredeploy-blobforwarder.json",
+        "bicep/azuredeploy-eventhubforwarder.bicep"
       ],
       "placeholder": "0.0.0-development"
     }],

--- a/armTemplates/azuredeploy-blobforwarder.json
+++ b/armTemplates/azuredeploy-blobforwarder.json
@@ -60,11 +60,18 @@
       "metadata": {
           "description": "Disables public network access to the Storage Account (please note that even without enabling this option, access to the Storage Account is secured). As a consequence, communication with the Service Account will be performed through a private Virtual Network (VNet). Please note that due to this, the hosting pricing plan for the Function app server farm will need to be upgraded to 'Basic', as it is the minimum one providing VNet integration for Function apps (you can later upgrade this plan if you require more scaling options). Also note that the following extra resources will be created: a virtual network, a subnet, DNS zone names, virtual network links, private endpoints and a Storage Account file share."
       }
+    },
+    "packageVersion": {
+      "type": "string",
+      "defaultValue": "0.0.0-development",
+      "metadata": {
+        "description": "Optional. Version of the newrelic-azure-functions deployment package to install, hosted in Azure Blob Storage (e.g. '3.3.1'). Defaults to the latest version tested with this template at release time."
+      }
     }
   },
   "variables": {
     "targetStorageAccountId": "[resourceId('Microsoft.Storage/storageAccounts', parameters('targetStorageAccountName'))]",
-    "blobForwarderFunctionArtifact": "https://github.com/newrelic/newrelic-azure-functions/releases/latest/download/LogForwarder.zip",
+    "blobForwarderFunctionArtifact": "[concat('https://nrloggingprodreleases.blob.core.windows.net/releases/log-forwarder-', parameters('packageVersion'), '.zip')]",
     "onePerResourceGroupUniqueSuffix": "[uniqueString(resourceGroup().id)]",
     "onePerResourceGroupAndStorageAccountAndContainer": "[uniqueString(resourceGroup().id, parameters('targetStorageAccountName'), parameters('targetContainerName'))]",
     "functionAppName": "[concat('nrlogs-blobforwarder-', variables('onePerResourceGroupAndStorageAccountAndContainer'))]",

--- a/armTemplates/azuredeploy-eventhubforwarder.json
+++ b/armTemplates/azuredeploy-eventhubforwarder.json
@@ -167,6 +167,13 @@
             "metadata": {
                 "description": "Optional. Disables public network access to the Storage Account (please note that even without enabling this option, access to the Storage Account is secured). As a consequence, communication with the Service Account will be performed through a private Virtual Network (VNet). Please note that due to this, the hosting pricing plan for the Function app server farm will need to be upgraded to 'Basic', as it is the minimum one providing VNet integration for Function apps (you can later upgrade this plan if you require more scaling options). Also note that the following extra resources will be created: a virtual network, a subnet, DNS zone names, virtual network links, private endpoints and a Storage Account file share."
             }
+        },
+        "packageVersion": {
+            "type": "string",
+            "defaultValue": "0.0.0-development",
+            "metadata": {
+                "description": "Optional. Version of the newrelic-azure-functions deployment package to install, hosted in Azure Blob Storage (e.g. '3.3.1'). Defaults to the latest version tested with this template at release time."
+            }
         }
     },
     "variables": {
@@ -185,7 +192,7 @@
         "functionAppName": "[concat('nrlogs-eventhubforwarder-', variables('onePerResourceGroupAndEventHubUniqueSuffix'))]",
         "activityLogsDiagnosticSettingName": "[concat('nrlogs-activity-log-diagnostic-setting-', variables('onePerResourceGroupAndEventHubUniqueSuffix'))]",
         "createActivityLogsDiagnosticSetting": "[or(parameters('forwardAdministrativeAzureActivityLogs'), parameters('forwardAlertAzureActivityLogs'), parameters('forwardAutoscaleAzureActivityLogs'), parameters('forwardPolicyAzureActivityLogs'), parameters('forwardRecommendationAzureActivityLogs'), parameters('forwardResourceHealthAzureActivityLogs'), parameters('forwardSecurityAzureActivityLogs'), parameters('forwardServiceHealthAzureActivityLogs'))]",
-        "eventHubForwarderFunctionArtifact": "https://github.com/newrelic/newrelic-azure-functions/releases/latest/download/LogForwarder.zip",
+        "eventHubForwarderFunctionArtifact": "[concat('https://nrloggingprodreleases.blob.core.windows.net/releases/log-forwarder-', parameters('packageVersion'), '.zip')]",
         "virtualNetworkName": "[format('nrlogs{0}-virtual-network', variables('onePerResourceGroupUniqueSuffix'))]",
         "functionSubnetName": "[format('{0}-internal-functions-subnet', variables('virtualNetworkName'))]",
         "privateEndpointsSubnetName": "[format('{0}-private-endpoints-subnet', variables('virtualNetworkName'))]",

--- a/bicep/azuredeploy-eventhubforwarder.bicep
+++ b/bicep/azuredeploy-eventhubforwarder.bicep
@@ -77,6 +77,9 @@ param maxWaitTime string = '00:00:30'
 ])
 param authenticationMode string = 'Local Authentication'
 
+@description('Optional. Version of the newrelic-azure-functions deployment package to install, hosted in Azure Blob Storage (e.g. \'3.3.1\'). Defaults to the latest version tested with this template at release time.')
+param packageVersion string = '0.0.0-development'
+
 var location_var = ((location == '') ? resourceGroup().location : location)
 var onePerResourceGroupUniqueSuffix = uniqueString(resourceGroup().id)
 var createNewEventHubNamespace = (eventHubNamespace == '')
@@ -98,7 +101,7 @@ var onePerResourceGroupAndEventHubUniqueSuffix = uniqueString(
 var functionAppName = 'nrlogs-eventhubforwarder-${onePerResourceGroupAndEventHubUniqueSuffix}'
 var activityLogsDiagnosticSettingName = 'nrlogs-activity-log-diagnostic-setting-${onePerResourceGroupAndEventHubUniqueSuffix}'
 var createActivityLogsDiagnosticSetting = (forwardAdministrativeAzureActivityLogs || forwardAlertAzureActivityLogs || forwardAutoscaleAzureActivityLogs || forwardPolicyAzureActivityLogs || forwardRecommendationAzureActivityLogs || forwardResourceHealthAzureActivityLogs || forwardSecurityAzureActivityLogs || forwardServiceHealthAzureActivityLogs)
-var eventHubForwarderFunctionArtifact = 'https://github.com/newrelic/newrelic-azure-functions/releases/latest/download/LogForwarder.zip'
+var eventHubForwarderFunctionArtifact = 'https://nrloggingprodreleases.blob.core.windows.net/releases/log-forwarder-${packageVersion}.zip'
 var virtualNetworkName = 'nrlogs${onePerResourceGroupUniqueSuffix}-virtual-network'
 var functionSubnetName = '${virtualNetworkName}-internal-functions-subnet'
 var privateEndpointsSubnetName = '${virtualNetworkName}-private-endpoints-subnet'


### PR DESCRIPTION
## What does this PR do? Why is it needed?

Updates both ARM templates (and the Bicep template) to fetch the deployment package from Azure Blob Storage instead of GitHub. Adds a `packageVersion` parameter so the URL is built dynamically (`releases/log-forwarder-<version>.zip`) instead of hardcoding a GitHub URL.

Customers were hitting intermittent SSL certificate-chain failures when Azure downloaded packages from GitHub Release URLs — flagged as risky by Microsoft. This fixes that by pointing to our own Azure-hosted artifacts instead. 


## Special notes for your reviewer

- `packageVersion` defaults to a placeholder (`0.0.0-development`) in source — it gets auto-filled with the real version on every release, same mechanism already used for `LogForwarder/index.js`.


## Details of Testing Done

- Deployed the EventHub template manually in a sandbox subscription with `packageVersion=3.3.1`.
- Confirmed the Function App deployed successfully and is running the real `3.3.1` package (verified via `plugin.version` in New Relic log attributes).
- Sent test events through the Event Hub and confirmed logs arrived in New Relic end-to-end.

## Checklist

- [x] Unit tests updated — N/A (template config only)
- [x] Documentation updated in README.md — N/A, no customer-facing setup steps changed
- [x] Manual testing details added
